### PR TITLE
Add option to use clingo from PATH

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
+const which = require('which');
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -23,6 +24,15 @@ function activate(context) {
 	}
 	else if (os == "linux" || os == "Linux") {
 		var path = context.asAbsolutePath("clingo_linux");
+	}
+
+	const usePathClingo = vscode.workspace.getConfiguration('aspLanguage').get("usePathClingo");
+	if (usePathClingo) {
+		try {
+			var path = which.sync("clingo");
+		} catch (e) {
+			vscode.window.showErrorMessage("clingo was not found on your PATH. Disable the 'usePathClingo' option to use the bundled version of clingo");
+		}
 	}
 
 	let disposable = vscode.commands.registerCommand('answer-set-programming-language-support.runinterminalall', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
 	"name": "answer-set-programming-language-support",
+	"version": "0.2.9",
 	"lockfileVersion": 1,
-	"version": "0.2.7",
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
@@ -338,6 +338,15 @@
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -1007,8 +1016,7 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -1187,6 +1195,15 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
 					}
 				}
 			}
@@ -1712,10 +1729,9 @@
 			}
 		},
 		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"requires": {
 				"isexe": "^2.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -61,10 +61,15 @@
 							"Any Linux Distribution"
 						]
 					},
+					"aspLanguage.usePathClingo": {
+						"description": "Set this option if you would like to use the Clingo version from your PATH instead of the version included",
+						"type": "boolean",
+						"default": false
+					},
 					"aspLanguage.terminalMode": {
-							"description": "Create new Terminal after every execution?",
-							"type": "boolean",
-							"default": false
+						"description": "Create new Terminal after every execution?",
+						"type": "boolean",
+						"default": false
 					}
 				},
 				"type": "string",
@@ -129,5 +134,8 @@
 		"mocha": "^7.1.2",
 		"typescript": "^3.8.3",
 		"vscode-test": "^1.3.0"
+	},
+	"dependencies": {
+		"which": "^2.0.2"
 	}
 }


### PR DESCRIPTION
It is desirable to bring your own version of clingo if you have made modifications or compiled it to have Python language support. If enabled, this option will search the user's path for a clingo installation instead of using the bundled clingo executables.