### PR TITLE
config file support for Mac fixed

### DIFF
--- a/configReader.js
+++ b/configReader.js
@@ -11,7 +11,7 @@ var jsonConfig;
  */
 function readConfig(setConfig, turnMessagesOff, contextAbsolutePath) {
     let args = "";
-    const pathToConfig = `${dirname(vscode.window.activeTextEditor.document.fileName)}\\${setConfig}`;
+    const pathToConfig = `${dirname(vscode.window.activeTextEditor.document.fileName)}/${setConfig}`;
     if (setConfig.match(/json$/i)) {
             jsonConfig = JSON.parse(fs.readFileSync(pathToConfig).toString());
 
@@ -44,7 +44,7 @@ function readConfig(setConfig, turnMessagesOff, contextAbsolutePath) {
  */
 function validateConfigSchema(contextAbsolutePath,pathToConfig) {
     const ajv = new Ajv();``
-    const schema = require(contextAbsolutePath+"\\schema.json");
+    const schema = require(contextAbsolutePath+"/schema.json");
     const validate = ajv.compile(schema);
     const valid = validate(jsonConfig);
     if (!valid) vscode.window.showInformationMessage(`Config file ${pathToConfig} is not as expected: ${validate.errors}`);
@@ -53,7 +53,7 @@ function validateConfigSchema(contextAbsolutePath,pathToConfig) {
 function readFiles() {
     if (jsonConfig.additionalFiles != undefined) {
         const fileList = jsonConfig.additionalFiles.map(file => 
-            `"${dirname(vscode.window.activeTextEditor.document.fileName)}\\${file}"`
+            `"${dirname(vscode.window.activeTextEditor.document.fileName)}/${file}"`
         );
         return ` ${fileList}`
     } else {

--- a/extension.js
+++ b/extension.js
@@ -107,7 +107,7 @@ function activate(context) {
 	const computeConfigCommand = vscode.commands.registerCommand('answer-set-programming-language-support.runinterminalconfig', function () {
 		createTerminal();
 
-		if (fs.existsSync(`${dirname(vscode.window.activeTextEditor.document.fileName)}\\${setConfig}`)) {
+		if (fs.existsSync(`${dirname(vscode.window.activeTextEditor.document.fileName)}/${setConfig}`)) {
 			additionalArgs = readConfig(setConfig, turnMessagesOff, context.asAbsolutePath(""));
 
 			terminal.show();
@@ -127,8 +127,8 @@ function activate(context) {
 	const initClingoConfig = vscode.commands.registerCommand('answer-set-programming-language-support.initClingoConfig', function () {
 		createTerminal();
 
-		const sampleConfig = fs.readFileSync(`${context.asAbsolutePath("")}\\sampleConfig.json`);
-		fs.writeFileSync(`${dirname(vscode.window.activeTextEditor.document.fileName)}\\config.json`, sampleConfig);
+		const sampleConfig = fs.readFileSync(`${context.asAbsolutePath("")}/sampleConfig.json`);
+		fs.writeFileSync(`${dirname(vscode.window.activeTextEditor.document.fileName)}/config.json`, sampleConfig);
 		
 		vscode.workspace.getConfiguration('aspLanguage').update("setConfig", "config.json");
 	});


### PR DESCRIPTION
This should fix the problems with config file access under Mac OS (due to the different folder delimiter)