### PR TITLE
Join fileList with space

### DIFF
--- a/configReader.js
+++ b/configReader.js
@@ -55,7 +55,7 @@ function readFiles() {
         const fileList = jsonConfig.additionalFiles.map(file => 
             `"${join(dirname(vscode.window.activeTextEditor.document.fileName), file)}"`
         );
-        return ` ${fileList}`
+        return ` ${fileList.join(' ')}`
     } else {
         return ``;
     }


### PR DESCRIPTION
Join fileList with space.

By default, JavaScript joins the strings in the list with a comma, but clingo expects the filename to be separated with a space.