### PR TITLE
Add openvsx publishing action to workflow

### DIFF
--- a/.github/workflows/marketplace_release.yml
+++ b/.github/workflows/marketplace_release.yml
@@ -35,7 +35,12 @@ jobs:
             - name: Install Dependencies
               run: npm ci
 
-            - name: Package Extension
+            - name: Publish to Open VSX Registry
+              uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db
+              with:
+                  pat: ${{ secrets.OPEN_VSX_RELEASE_TOKEN }}
+
+            - name: Publish to Visual Studio Marketplace
               id: packageExtension
               uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2.0.0
               with:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Downloads](https://vsmarketplacebadges.dev/downloads-short/ffrankreiter.answer-set-programming-language-support.png)](https://marketplace.visualstudio.com/items?itemName=ffrankreiter.answer-set-programming-language-support)
 [![Rating](https://vsmarketplacebadges.dev/rating-short/ffrankreiter.answer-set-programming-language-support.png)](https://marketplace.visualstudio.com/items?itemName=ffrankreiter.answer-set-programming-language-support)
 
-| [Potassco](https://potassco.org/) | [Potassco on Github](https://github.com/potassco) | [Clingo](https://potassco.org/clingo/) |
+| [Potassco](https://potassco.org/) | [Potassco on Github](https://github.com/potassco) | [Clingo](https://potassco.org/clingo/) | [Get it on Open VSX Registry](https://open-vsx.org/extension/ffrankreiter/answer-set-programming-language-support)
 
 This Extension uses Clingo Answer Set Solver (bundled), developed by Potassco (University of Potsdam).
 We added multi-file support with v0.4.0!


### PR DESCRIPTION
@richilino please check if this would work and is sufficient, I already added the access token to the repository secrets :)
Also I published the most recent vsix package manually so we dont have to run it for now: [ASP on Open VSX Registry](https://open-vsx.org/extension/ffrankreiter/answer-set-programming-language-support)