### PR TITLE
fix: :bug: fixed multiline comments being processed incorrectly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3065,9 +3065,10 @@
             }
         },
         "../clingo-wasm/node_modules/brace-expansion": {
-            "version": "1.1.11",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6713,9 +6714,10 @@
             }
         },
         "../clingo-wasm/node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "2.0.1",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -10332,9 +10334,10 @@
             }
         },
         "node_modules/@vscode/test-cli/node_modules/brace-expansion": {
-            "version": "2.0.1",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -10877,9 +10880,10 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12167,9 +12171,10 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.3",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -14125,9 +14130,10 @@
             }
         },
         "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.1",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -16416,9 +16422,10 @@
             "license": "MIT"
         },
         "node_modules/vscode-extension-tester/node_modules/brace-expansion": {
-            "version": "2.0.1",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "answer-set-programming-language-support",
-    "version": "1.0.0",
+    "version": "1.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "answer-set-programming-language-support",
-            "version": "1.0.0",
+            "version": "1.0.3",
             "dependencies": {
                 "@vscode/codicons": "0.0.36",
                 "ajv": "^8.17.1",
-                "clingo-wasm": "^0.3.2",
+                "clingo-wasm": "file:../clingo-wasm",
                 "which": "^5.0.0"
             },
             "devDependencies": {
@@ -22,6 +22,32 @@
             },
             "engines": {
                 "vscode": ">=1.63.0"
+            }
+        },
+        "../clingo-wasm": {
+            "version": "0.3.2",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/emscripten": "^1.40.0"
+            },
+            "devDependencies": {
+                "@babel/core": "^7.26.10",
+                "@babel/preset-env": "^7.26.9",
+                "@babel/preset-typescript": "^7.26.0",
+                "@types/jest": "^29.5.14",
+                "@types/node": "^22.13.10",
+                "exports-loader": "^5.0.0",
+                "file-loader": "^6.2.0",
+                "gh-pages": "^6.3.0",
+                "jest": "^29.7.0",
+                "rimraf": "^6.0.1",
+                "serve": "^14.2.4",
+                "ts-loader": "^9.5.2",
+                "typescript": "^5.8.2",
+                "webpack": "^5.98.0",
+                "webpack-cli": "^6.0.1",
+                "webpack-dev-server": "^5.2.0",
+                "worker-loader": "^3.0.8"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1406,11 +1432,6 @@
                 "@babel/types": "^7.20.7"
             }
         },
-        "node_modules/@types/emscripten": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.40.0.tgz",
-            "integrity": "sha512-MD2JJ25S4tnjnhjWyalMS6K6p0h+zQV6+Ylm+aGbiS8tSn/aHLSGNzBgduj6FB4zH0ax2GRMGYi/8G1uOxhXWA=="
-        },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.9",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2764,13 +2785,8 @@
             }
         },
         "node_modules/clingo-wasm": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/clingo-wasm/-/clingo-wasm-0.3.2.tgz",
-            "integrity": "sha512-0ZdaGgekZaO8hLF3PE0fcs4FjR+GAdVeMTTzVgm8L1OuCl4A8+/H1V8urBMJYlV6+HH+gAweDxFq1MVgM4lDKQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/emscripten": "^1.40.0"
-            }
+            "resolved": "../clingo-wasm",
+            "link": true
         },
         "node_modules/clipboardy": {
             "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8586 +24,11 @@
                 "vscode": ">=1.63.0"
             }
         },
-        "../clingo-wasm": {
-            "version": "0.3.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/emscripten": "^1.40.0"
-            },
-            "devDependencies": {
-                "@babel/core": "^7.26.10",
-                "@babel/preset-env": "^7.26.9",
-                "@babel/preset-typescript": "^7.26.0",
-                "@types/jest": "^29.5.14",
-                "@types/node": "^22.13.10",
-                "exports-loader": "^5.0.0",
-                "file-loader": "^6.2.0",
-                "gh-pages": "^6.3.0",
-                "jest": "^29.7.0",
-                "rimraf": "^6.0.1",
-                "serve": "^14.2.4",
-                "ts-loader": "^9.5.2",
-                "typescript": "^5.8.2",
-                "webpack": "^5.98.0",
-                "webpack-cli": "^6.0.1",
-                "webpack-dev-server": "^5.2.0",
-                "worker-loader": "^3.0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.1.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/compat-data": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/core": {
-            "version": "7.26.10",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.26.10",
-                "@babel/helper-compilation-targets": "^7.26.5",
-                "@babel/helper-module-transforms": "^7.26.0",
-                "@babel/helpers": "^7.26.10",
-                "@babel/parser": "^7.26.10",
-                "@babel/template": "^7.26.9",
-                "@babel/traverse": "^7.26.10",
-                "@babel/types": "^7.26.10",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/generator": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.27.1",
-                "@babel/types": "^7.27.1",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/compat-data": "^7.27.1",
-                "@babel/helper-validator-option": "^7.27.1",
-                "browserslist": "^4.24.0",
-                "lru-cache": "^5.1.1",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-member-expression-to-functions": "^7.27.1",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/traverse": "^7.27.1",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "regexpu-core": "^6.2.0",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-compilation-targets": "^7.22.6",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "debug": "^4.1.1",
-                "lodash.debounce": "^4.0.8",
-                "resolve": "^1.14.2"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-module-imports": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-module-transforms": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-plugin-utils": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-remap-async-to-generator": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-wrap-function": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-replace-supers": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.27.1",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helper-wrap-function": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/template": "^7.27.1",
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/helpers": {
-            "version": "7.26.10",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/template": "^7.26.9",
-                "@babel/types": "^7.26.10"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/parser": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.27.1"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/plugin-transform-optional-chaining": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.13.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-proposal-private-property-in-object": {
-            "version": "7.21.0-placeholder-for-preset-env.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-async-generators": {
-            "version": "7.8.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-bigint": {
-            "version": "7.8.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-class-properties": {
-            "version": "7.12.13",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.12.13"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-class-static-block": {
-            "version": "7.14.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-import-meta": {
-            "version": "7.10.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-json-strings": {
-            "version": "7.8.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-            "version": "7.10.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-            "version": "7.8.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-numeric-separator": {
-            "version": "7.10.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-object-rest-spread": {
-            "version": "7.8.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-optional-catch-binding": {
-            "version": "7.8.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-optional-chaining": {
-            "version": "7.8.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-private-property-in-object": {
-            "version": "7.14.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-top-level-await": {
-            "version": "7.14.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-syntax-unicode-sets-regex": {
-            "version": "7.18.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.18.6",
-                "@babel/helper-plugin-utils": "^7.18.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-remap-async-to-generator": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-remap-async-to-generator": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-class-properties": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-class-static-block": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.12.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-classes": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-compilation-targets": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1",
-                "@babel/traverse": "^7.27.1",
-                "globals": "^11.1.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/template": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-duplicate-keys": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-dynamic-import": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-export-namespace-from": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-compilation-targets": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-json-strings": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-literals": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-logical-assignment-operators": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-modules-umd": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-new-target": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-numeric-separator": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-object-rest-spread": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-compilation-targets": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/plugin-transform-parameters": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-optional-catch-binding": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-private-methods": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-private-property-in-object": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-regexp-modifiers": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-reserved-words": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-spread": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-sticky-regex": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/plugin-syntax-typescript": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-unicode-property-regex": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-unicode-regex": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/preset-env": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/compat-data": "^7.27.1",
-                "@babel/helper-compilation-targets": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
-                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
-                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
-                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
-                "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-                "@babel/plugin-syntax-import-assertions": "^7.27.1",
-                "@babel/plugin-syntax-import-attributes": "^7.27.1",
-                "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-                "@babel/plugin-transform-arrow-functions": "^7.27.1",
-                "@babel/plugin-transform-async-generator-functions": "^7.27.1",
-                "@babel/plugin-transform-async-to-generator": "^7.27.1",
-                "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-                "@babel/plugin-transform-block-scoping": "^7.27.1",
-                "@babel/plugin-transform-class-properties": "^7.27.1",
-                "@babel/plugin-transform-class-static-block": "^7.27.1",
-                "@babel/plugin-transform-classes": "^7.27.1",
-                "@babel/plugin-transform-computed-properties": "^7.27.1",
-                "@babel/plugin-transform-destructuring": "^7.27.1",
-                "@babel/plugin-transform-dotall-regex": "^7.27.1",
-                "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
-                "@babel/plugin-transform-dynamic-import": "^7.27.1",
-                "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
-                "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-                "@babel/plugin-transform-for-of": "^7.27.1",
-                "@babel/plugin-transform-function-name": "^7.27.1",
-                "@babel/plugin-transform-json-strings": "^7.27.1",
-                "@babel/plugin-transform-literals": "^7.27.1",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
-                "@babel/plugin-transform-member-expression-literals": "^7.27.1",
-                "@babel/plugin-transform-modules-amd": "^7.27.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-                "@babel/plugin-transform-modules-systemjs": "^7.27.1",
-                "@babel/plugin-transform-modules-umd": "^7.27.1",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
-                "@babel/plugin-transform-new-target": "^7.27.1",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-                "@babel/plugin-transform-numeric-separator": "^7.27.1",
-                "@babel/plugin-transform-object-rest-spread": "^7.27.1",
-                "@babel/plugin-transform-object-super": "^7.27.1",
-                "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
-                "@babel/plugin-transform-optional-chaining": "^7.27.1",
-                "@babel/plugin-transform-parameters": "^7.27.1",
-                "@babel/plugin-transform-private-methods": "^7.27.1",
-                "@babel/plugin-transform-private-property-in-object": "^7.27.1",
-                "@babel/plugin-transform-property-literals": "^7.27.1",
-                "@babel/plugin-transform-regenerator": "^7.27.1",
-                "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
-                "@babel/plugin-transform-reserved-words": "^7.27.1",
-                "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-                "@babel/plugin-transform-spread": "^7.27.1",
-                "@babel/plugin-transform-sticky-regex": "^7.27.1",
-                "@babel/plugin-transform-template-literals": "^7.27.1",
-                "@babel/plugin-transform-typeof-symbol": "^7.27.1",
-                "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-                "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
-                "@babel/plugin-transform-unicode-regex": "^7.27.1",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
-                "@babel/preset-modules": "0.1.6-no-external-plugins",
-                "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.11.0",
-                "babel-plugin-polyfill-regenerator": "^0.6.1",
-                "core-js-compat": "^3.40.0",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/preset-modules": {
-            "version": "0.1.6-no-external-plugins",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/types": "^7.4.4",
-                "esutils": "^2.0.2"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/preset-typescript": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-syntax-jsx": "^7.27.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-                "@babel/plugin-transform-typescript": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/template": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/parser": "^7.27.1",
-                "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/traverse": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.27.1",
-                "@babel/parser": "^7.27.1",
-                "@babel/template": "^7.27.1",
-                "@babel/types": "^7.27.1",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@babel/types": {
-            "version": "7.27.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@bcoe/v8-coverage": {
-            "version": "0.2.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@discoveryjs/json-ext": {
-            "version": "0.6.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.17.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@isaacs/cliui": {
-            "version": "8.0.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^5.1.2",
-                "string-width-cjs": "npm:string-width@^4.2.0",
-                "strip-ansi": "^7.0.1",
-                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-                "wrap-ansi": "^8.1.0",
-                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "../clingo-wasm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/@istanbuljs/load-nyc-config": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "camelcase": "^5.3.1",
-                "find-up": "^4.1.0",
-                "get-package-type": "^0.1.0",
-                "js-yaml": "^3.13.1",
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/@istanbuljs/schema": {
-            "version": "0.1.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/console": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/core": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/reporters": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
-                "jest-changed-files": "^29.7.0",
-                "jest-config": "^29.7.0",
-                "jest-haste-map": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-resolve-dependencies": "^29.7.0",
-                "jest-runner": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "jest-watcher": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/environment": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "jest-mock": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/expect": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "expect": "^29.7.0",
-                "jest-snapshot": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/expect-utils": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "jest-get-type": "^29.6.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/fake-timers": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@sinonjs/fake-timers": "^10.0.2",
-                "@types/node": "*",
-                "jest-message-util": "^29.7.0",
-                "jest-mock": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/globals": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/expect": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "jest-mock": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/reporters": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "collect-v8-coverage": "^1.0.0",
-                "exit": "^0.1.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "istanbul-lib-coverage": "^3.0.0",
-                "istanbul-lib-instrument": "^6.0.0",
-                "istanbul-lib-report": "^3.0.0",
-                "istanbul-lib-source-maps": "^4.0.0",
-                "istanbul-reports": "^3.1.3",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "slash": "^3.0.0",
-                "string-length": "^4.0.1",
-                "strip-ansi": "^6.0.0",
-                "v8-to-istanbul": "^9.0.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/schemas": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.27.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/source-map": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "callsites": "^3.0.0",
-                "graceful-fs": "^4.2.9"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/test-result": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "collect-v8-coverage": "^1.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/test-sequencer": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/test-result": "^29.7.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/transform": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@jest/types": "^29.6.3",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "babel-plugin-istanbul": "^6.1.1",
-                "chalk": "^4.0.0",
-                "convert-source-map": "^2.0.0",
-                "fast-json-stable-stringify": "^2.1.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "pirates": "^4.0.4",
-                "slash": "^3.0.0",
-                "write-file-atomic": "^4.0.2"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@jridgewell/source-map": {
-            "version": "0.3.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25"
-            }
-        },
-        "../clingo-wasm/node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.1.0",
-                "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
-        "../clingo-wasm/node_modules/@jsonjoy.com/base64": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
-            }
-        },
-        "../clingo-wasm/node_modules/@jsonjoy.com/json-pack": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jsonjoy.com/base64": "^1.1.1",
-                "@jsonjoy.com/util": "^1.1.2",
-                "hyperdyperid": "^1.2.0",
-                "thingies": "^1.20.0"
-            },
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
-            }
-        },
-        "../clingo-wasm/node_modules/@jsonjoy.com/util": {
-            "version": "1.5.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
-            }
-        },
-        "../clingo-wasm/node_modules/@leichtgewicht/ip-codec": {
-            "version": "2.0.5",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "../clingo-wasm/node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "../clingo-wasm/node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "../clingo-wasm/node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@sinonjs/commons": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/@sinonjs/fake-timers": {
-            "version": "10.3.0",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/babel__core": {
-            "version": "7.20.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.20.7",
-                "@babel/types": "^7.20.7",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/babel__generator": {
-            "version": "7.6.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/babel__template": {
-            "version": "7.4.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/babel__traverse": {
-            "version": "7.20.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.20.7"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/body-parser": {
-            "version": "1.19.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/connect": "*",
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/bonjour": {
-            "version": "3.5.13",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/connect": {
-            "version": "3.4.38",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/connect-history-api-fallback": {
-            "version": "1.5.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/express-serve-static-core": "*",
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/emscripten": {
-            "version": "1.40.1",
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/eslint": {
-            "version": "9.6.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "*",
-                "@types/json-schema": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/eslint-scope": {
-            "version": "3.7.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/eslint": "*",
-                "@types/estree": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/estree": {
-            "version": "1.0.6",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/express": {
-            "version": "4.17.21",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
-                "@types/qs": "*",
-                "@types/serve-static": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/express-serve-static-core": {
-            "version": "5.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/express/node_modules/@types/express-serve-static-core": {
-            "version": "4.19.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/graceful-fs": {
-            "version": "4.1.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/http-errors": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/http-proxy": {
-            "version": "1.17.16",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/istanbul-lib-coverage": {
-            "version": "2.0.6",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/istanbul-lib-report": {
-            "version": "3.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/istanbul-lib-coverage": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/istanbul-reports": {
-            "version": "3.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/istanbul-lib-report": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/jest": {
-            "version": "29.5.14",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "expect": "^29.0.0",
-                "pretty-format": "^29.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/json-schema": {
-            "version": "7.0.15",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/mime": {
-            "version": "1.3.5",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/node": {
-            "version": "22.15.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/node-forge": {
-            "version": "1.3.11",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/qs": {
-            "version": "6.9.18",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/range-parser": {
-            "version": "1.2.7",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/retry": {
-            "version": "0.12.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/send": {
-            "version": "0.17.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/mime": "^1",
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/serve-index": {
-            "version": "1.9.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/express": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/serve-static": {
-            "version": "1.15.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-errors": "*",
-                "@types/node": "*",
-                "@types/send": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/sockjs": {
-            "version": "0.3.36",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/stack-utils": {
-            "version": "2.0.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@types/ws": {
-            "version": "8.18.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/yargs": {
-            "version": "17.0.33",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/@types/yargs-parser": {
-            "version": "21.0.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/ast": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@webassemblyjs/helper-numbers": "1.13.2",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-            }
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.13.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/helper-api-error": {
-            "version": "1.13.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/helper-numbers": {
-            "version": "1.13.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": "1.13.2",
-                "@webassemblyjs/helper-api-error": "1.13.2",
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.13.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-buffer": "1.14.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-                "@webassemblyjs/wasm-gen": "1.14.1"
-            }
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/ieee754": {
-            "version": "1.13.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@xtuc/ieee754": "^1.2.0"
-            }
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/leb128": {
-            "version": "1.13.2",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/utf8": {
-            "version": "1.13.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-buffer": "1.14.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-                "@webassemblyjs/helper-wasm-section": "1.14.1",
-                "@webassemblyjs/wasm-gen": "1.14.1",
-                "@webassemblyjs/wasm-opt": "1.14.1",
-                "@webassemblyjs/wasm-parser": "1.14.1",
-                "@webassemblyjs/wast-printer": "1.14.1"
-            }
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-                "@webassemblyjs/ieee754": "1.13.2",
-                "@webassemblyjs/leb128": "1.13.2",
-                "@webassemblyjs/utf8": "1.13.2"
-            }
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-buffer": "1.14.1",
-                "@webassemblyjs/wasm-gen": "1.14.1",
-                "@webassemblyjs/wasm-parser": "1.14.1"
-            }
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-api-error": "1.13.2",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-                "@webassemblyjs/ieee754": "1.13.2",
-                "@webassemblyjs/leb128": "1.13.2",
-                "@webassemblyjs/utf8": "1.13.2"
-            }
-        },
-        "../clingo-wasm/node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "../clingo-wasm/node_modules/@webpack-cli/configtest": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.12.0"
-            },
-            "peerDependencies": {
-                "webpack": "^5.82.0",
-                "webpack-cli": "6.x.x"
-            }
-        },
-        "../clingo-wasm/node_modules/@webpack-cli/info": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.12.0"
-            },
-            "peerDependencies": {
-                "webpack": "^5.82.0",
-                "webpack-cli": "6.x.x"
-            }
-        },
-        "../clingo-wasm/node_modules/@webpack-cli/serve": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.12.0"
-            },
-            "peerDependencies": {
-                "webpack": "^5.82.0",
-                "webpack-cli": "6.x.x"
-            },
-            "peerDependenciesMeta": {
-                "webpack-dev-server": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/@xtuc/ieee754": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
-        "../clingo-wasm/node_modules/@xtuc/long": {
-            "version": "4.2.2",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
-        "../clingo-wasm/node_modules/@zeit/schemas": {
-            "version": "2.36.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/accepts": {
-            "version": "1.3.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-types": "~2.1.34",
-                "negotiator": "0.6.3"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/acorn": {
-            "version": "8.14.1",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "../clingo-wasm/node_modules/ajv": {
-            "version": "6.12.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "../clingo-wasm/node_modules/ajv-formats": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.17.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "../clingo-wasm/node_modules/ajv-formats/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/ajv-keywords": {
-            "version": "3.5.2",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "ajv": "^6.9.1"
-            }
-        },
-        "../clingo-wasm/node_modules/ansi-align": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.1.0"
-            }
-        },
-        "../clingo-wasm/node_modules/ansi-align/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/ansi-align/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/ansi-html-community": {
-            "version": "0.0.8",
-            "dev": true,
-            "engines": [
-                "node >= 0.8.0"
-            ],
-            "license": "Apache-2.0",
-            "bin": {
-                "ansi-html": "bin/ansi-html"
-            }
-        },
-        "../clingo-wasm/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/anymatch": {
-            "version": "3.1.3",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "../clingo-wasm/node_modules/arch": {
-            "version": "2.2.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/arg": {
-            "version": "5.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/argparse": {
-            "version": "1.0.10",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "../clingo-wasm/node_modules/array-flatten": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/array-union": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/async": {
-            "version": "3.2.6",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/babel-jest": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/transform": "^29.7.0",
-                "@types/babel__core": "^7.1.14",
-                "babel-plugin-istanbul": "^6.1.1",
-                "babel-preset-jest": "^29.6.3",
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/babel-plugin-istanbul": {
-            "version": "6.1.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@istanbuljs/load-nyc-config": "^1.0.0",
-                "@istanbuljs/schema": "^0.1.2",
-                "istanbul-lib-instrument": "^5.0.4",
-                "test-exclude": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-            "version": "5.2.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@babel/core": "^7.12.3",
-                "@babel/parser": "^7.14.7",
-                "@istanbuljs/schema": "^0.1.2",
-                "istanbul-lib-coverage": "^3.2.0",
-                "semver": "^6.3.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/babel-plugin-jest-hoist": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/template": "^7.3.3",
-                "@babel/types": "^7.3.3",
-                "@types/babel__core": "^7.1.14",
-                "@types/babel__traverse": "^7.0.6"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.12",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/compat-data": "^7.22.6",
-                "@babel/helper-define-polyfill-provider": "^0.6.3",
-                "semver": "^6.3.1"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.11.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.3",
-                "core-js-compat": "^3.40.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.3"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/babel-preset-current-node-syntax": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/plugin-syntax-bigint": "^7.8.3",
-                "@babel/plugin-syntax-class-properties": "^7.12.13",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5",
-                "@babel/plugin-syntax-import-attributes": "^7.24.7",
-                "@babel/plugin-syntax-import-meta": "^7.10.4",
-                "@babel/plugin-syntax-json-strings": "^7.8.3",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-                "@babel/plugin-syntax-top-level-await": "^7.14.5"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/babel-preset-jest": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-plugin-jest-hoist": "^29.6.3",
-                "babel-preset-current-node-syntax": "^1.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/batch": {
-            "version": "0.6.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/big.js": {
-            "version": "5.2.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/binary-extensions": {
-            "version": "2.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/body-parser": {
-            "version": "1.20.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.13.0",
-                "raw-body": "2.5.2",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "../clingo-wasm/node_modules/body-parser/node_modules/bytes": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/body-parser/node_modules/debug": {
-            "version": "2.6.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/body-parser/node_modules/ms": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/bonjour-service": {
-            "version": "1.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "multicast-dns": "^7.2.5"
-            }
-        },
-        "../clingo-wasm/node_modules/boxen": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-align": "^3.0.1",
-                "camelcase": "^7.0.0",
-                "chalk": "^5.0.1",
-                "cli-boxes": "^3.0.0",
-                "string-width": "^5.1.2",
-                "type-fest": "^2.13.0",
-                "widest-line": "^4.0.1",
-                "wrap-ansi": "^8.0.1"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/boxen/node_modules/camelcase": {
-            "version": "7.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/boxen/node_modules/chalk": {
-            "version": "5.4.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/boxen/node_modules/type-fest": {
-            "version": "2.19.0",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "../clingo-wasm/node_modules/braces": {
-            "version": "3.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/browserslist": {
-            "version": "4.24.4",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "caniuse-lite": "^1.0.30001688",
-                "electron-to-chromium": "^1.5.73",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.1"
-            },
-            "bin": {
-                "browserslist": "cli.js"
-            },
-            "engines": {
-                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            }
-        },
-        "../clingo-wasm/node_modules/bser": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "node-int64": "^0.4.0"
-            }
-        },
-        "../clingo-wasm/node_modules/buffer-from": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/bundle-name": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "run-applescript": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/bytes": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "../clingo-wasm/node_modules/call-bound": {
-            "version": "1.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/callsites": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/camelcase": {
-            "version": "5.3.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/caniuse-lite": {
-            "version": "1.0.30001704",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "CC-BY-4.0"
-        },
-        "../clingo-wasm/node_modules/chalk": {
-            "version": "4.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/chalk-template": {
-            "version": "0.4.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk-template?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/char-regex": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/chokidar": {
-            "version": "3.6.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
-            },
-            "engines": {
-                "node": ">= 8.10.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
-            }
-        },
-        "../clingo-wasm/node_modules/chrome-trace-event": {
-            "version": "1.0.4",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "../clingo-wasm/node_modules/ci-info": {
-            "version": "3.9.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/cjs-module-lexer": {
-            "version": "1.4.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/cli-boxes": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/clipboardy": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "arch": "^2.2.0",
-                "execa": "^5.1.1",
-                "is-wsl": "^2.2.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/cliui": {
-            "version": "8.0.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "../clingo-wasm/node_modules/cliui/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/cliui/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/clone-deep": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-plain-object": "^2.0.4",
-                "kind-of": "^6.0.2",
-                "shallow-clone": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/co": {
-            "version": "4.6.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">= 1.0.0",
-                "node": ">= 0.12.0"
-            }
-        },
-        "../clingo-wasm/node_modules/collect-v8-coverage": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/color-convert": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/color-name": {
-            "version": "1.1.4",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/colorette": {
-            "version": "2.0.20",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/commander": {
-            "version": "13.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "../clingo-wasm/node_modules/commondir": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/compressible": {
-            "version": "2.0.18",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": ">= 1.43.0 < 2"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/compression": {
-            "version": "1.7.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "~1.3.5",
-                "bytes": "3.0.0",
-                "compressible": "~2.0.16",
-                "debug": "2.6.9",
-                "on-headers": "~1.0.2",
-                "safe-buffer": "5.1.2",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/compression/node_modules/debug": {
-            "version": "2.6.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/compression/node_modules/ms": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/concat-map": {
-            "version": "0.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/connect-history-api-fallback": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/content-disposition": {
-            "version": "0.5.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/content-type": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/cookie": {
-            "version": "0.7.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/cookie-signature": {
-            "version": "1.0.6",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/core-js-compat": {
-            "version": "3.41.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "browserslist": "^4.24.4"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "../clingo-wasm/node_modules/core-util-is": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/create-jest": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
-                "jest-config": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "prompts": "^2.0.1"
-            },
-            "bin": {
-                "create-jest": "bin/create-jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/cross-spawn": {
-            "version": "7.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "../clingo-wasm/node_modules/debug": {
-            "version": "4.4.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/dedent": {
-            "version": "1.5.3",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "babel-plugin-macros": "^3.1.0"
-            },
-            "peerDependenciesMeta": {
-                "babel-plugin-macros": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/deep-extend": {
-            "version": "0.6.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/deepmerge": {
-            "version": "4.3.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/default-browser": {
-            "version": "5.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bundle-name": "^4.1.0",
-                "default-browser-id": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/default-browser-id": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/define-lazy-prop": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/depd": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/destroy": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "../clingo-wasm/node_modules/detect-newline": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/detect-node": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/diff-sequences": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/dir-glob": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/dns-packet": {
-            "version": "5.6.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@leichtgewicht/ip-codec": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "../clingo-wasm/node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/ee-first": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/electron-to-chromium": {
-            "version": "1.5.116",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/email-addresses": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/emittery": {
-            "version": "0.13.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/emojis-list": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "../clingo-wasm/node_modules/encodeurl": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/enhanced-resolve": {
-            "version": "5.18.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "../clingo-wasm/node_modules/envinfo": {
-            "version": "7.14.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "envinfo": "dist/cli.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/error-ex": {
-            "version": "1.3.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-arrayish": "^0.2.1"
-            }
-        },
-        "../clingo-wasm/node_modules/es-define-property": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "../clingo-wasm/node_modules/es-errors": {
-            "version": "1.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "../clingo-wasm/node_modules/es-module-lexer": {
-            "version": "1.6.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "../clingo-wasm/node_modules/escalade": {
-            "version": "3.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/escape-html": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/esprima": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/esrecurse": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "../clingo-wasm/node_modules/esrecurse/node_modules/estraverse": {
-            "version": "5.3.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "../clingo-wasm/node_modules/estraverse": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "../clingo-wasm/node_modules/esutils": {
-            "version": "2.0.3",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/etag": {
-            "version": "1.8.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/events": {
-            "version": "3.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.x"
-            }
-        },
-        "../clingo-wasm/node_modules/execa": {
-            "version": "5.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/exit": {
-            "version": "0.1.2",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/expect": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/expect-utils": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/exports-loader": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "source-map": "^0.6.1"
-            },
-            "engines": {
-                "node": ">= 18.12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/express": {
-            "version": "4.21.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.3",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.7.1",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.3.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.13.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.19.0",
-                "serve-static": "1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "../clingo-wasm/node_modules/express/node_modules/content-disposition": {
-            "version": "0.5.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/express/node_modules/debug": {
-            "version": "2.6.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/express/node_modules/ms": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/express/node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/express/node_modules/range-parser": {
-            "version": "1.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/express/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/fast-deep-equal": {
-            "version": "3.1.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/fast-glob": {
-            "version": "3.3.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "../clingo-wasm/node_modules/fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/fast-uri": {
-            "version": "3.0.6",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause"
-        },
-        "../clingo-wasm/node_modules/fastest-levenshtein": {
-            "version": "1.0.16",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4.9.1"
-            }
-        },
-        "../clingo-wasm/node_modules/fastq": {
-            "version": "1.19.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
-        },
-        "../clingo-wasm/node_modules/faye-websocket": {
-            "version": "0.11.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "websocket-driver": ">=0.5.1"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/fb-watchman": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bser": "2.1.1"
-            }
-        },
-        "../clingo-wasm/node_modules/file-loader": {
-            "version": "6.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "loader-utils": "^2.0.0",
-                "schema-utils": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/filename-reserved-regex": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/filenamify": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "filename-reserved-regex": "^2.0.0",
-                "strip-outer": "^1.0.1",
-                "trim-repeated": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/fill-range": {
-            "version": "7.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/finalhandler": {
-            "version": "1.3.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "2.6.9",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "statuses": "2.0.1",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/finalhandler/node_modules/debug": {
-            "version": "2.6.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/finalhandler/node_modules/ms": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/find-cache-dir": {
-            "version": "3.3.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "commondir": "^1.0.1",
-                "make-dir": "^3.0.2",
-                "pkg-dir": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/find-up": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/flat": {
-            "version": "5.0.2",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "bin": {
-                "flat": "cli.js"
-            }
-        },
-        "../clingo-wasm/node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/foreground-child": {
-            "version": "3.3.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.6",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "../clingo-wasm/node_modules/foreground-child/node_modules/signal-exit": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "../clingo-wasm/node_modules/forwarded": {
-            "version": "0.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/fresh": {
-            "version": "0.5.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/fs-extra": {
-            "version": "11.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
-        "../clingo-wasm/node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/function-bind": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/gensync": {
-            "version": "1.0.0-beta.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/get-caller-file": {
-            "version": "2.0.5",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "../clingo-wasm/node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/get-package-type": {
-            "version": "0.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/get-proto": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "../clingo-wasm/node_modules/get-stream": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/gh-pages": {
-            "version": "6.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "async": "^3.2.4",
-                "commander": "^13.0.0",
-                "email-addresses": "^5.0.0",
-                "filenamify": "^4.3.0",
-                "find-cache-dir": "^3.3.1",
-                "fs-extra": "^11.1.1",
-                "globby": "^11.1.0"
-            },
-            "bin": {
-                "gh-pages": "bin/gh-pages.js",
-                "gh-pages-clean": "bin/gh-pages-clean.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/glob": {
-            "version": "7.2.3",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "../clingo-wasm/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "../clingo-wasm/node_modules/glob-to-regexp": {
-            "version": "0.4.1",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
-        "../clingo-wasm/node_modules/globals": {
-            "version": "11.12.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/globby": {
-            "version": "11.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/gopd": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/handle-thing": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/has-flag": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/has-symbols": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/hasown": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "../clingo-wasm/node_modules/hpack.js": {
-            "version": "2.1.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.1",
-                "obuf": "^1.0.0",
-                "readable-stream": "^2.0.1",
-                "wbuf": "^1.1.0"
-            }
-        },
-        "../clingo-wasm/node_modules/hpack.js/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "../clingo-wasm/node_modules/hpack.js/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "../clingo-wasm/node_modules/html-escaper": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/http-deceiver": {
-            "version": "1.2.7",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/http-errors": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/http-parser-js": {
-            "version": "0.5.9",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/http-proxy": {
-            "version": "1.18.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^4.0.0",
-                "follow-redirects": "^1.0.0",
-                "requires-port": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-proxy": "^1.17.8",
-                "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.1",
-                "is-plain-obj": "^3.0.0",
-                "micromatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "@types/express": "^4.17.13"
-            },
-            "peerDependenciesMeta": {
-                "@types/express": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/human-signals": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.17.0"
-            }
-        },
-        "../clingo-wasm/node_modules/hyperdyperid": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.18"
-            }
-        },
-        "../clingo-wasm/node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/ignore": {
-            "version": "5.3.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "../clingo-wasm/node_modules/import-local": {
-            "version": "3.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pkg-dir": "^4.2.0",
-                "resolve-cwd": "^3.0.0"
-            },
-            "bin": {
-                "import-local-fixture": "fixtures/cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/imurmurhash": {
-            "version": "0.1.4",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.19"
-            }
-        },
-        "../clingo-wasm/node_modules/inflight": {
-            "version": "1.0.6",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "../clingo-wasm/node_modules/inherits": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/ini": {
-            "version": "1.3.8",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/interpret": {
-            "version": "3.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "../clingo-wasm/node_modules/ipaddr.js": {
-            "version": "2.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "../clingo-wasm/node_modules/is-arrayish": {
-            "version": "0.2.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/is-binary-path": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "binary-extensions": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/is-core-module": {
-            "version": "2.16.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/is-docker": {
-            "version": "2.2.1",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/is-extglob": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/is-generator-fn": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/is-glob": {
-            "version": "4.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/is-inside-container": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^3.0.0"
-            },
-            "bin": {
-                "is-inside-container": "cli.js"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/is-inside-container/node_modules/is-docker": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/is-network-error": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/is-number": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
-        "../clingo-wasm/node_modules/is-plain-obj": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/is-plain-object": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "isobject": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/is-port-reachable": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/is-stream": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/is-wsl": {
-            "version": "2.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/isarray": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/isexe": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/isobject": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/istanbul-lib-coverage": {
-            "version": "3.2.2",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/istanbul-lib-instrument": {
-            "version": "6.0.3",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@babel/core": "^7.23.9",
-                "@babel/parser": "^7.23.9",
-                "@istanbuljs/schema": "^0.1.3",
-                "istanbul-lib-coverage": "^3.2.0",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "7.7.1",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/istanbul-lib-report": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "istanbul-lib-coverage": "^3.0.0",
-                "make-dir": "^4.0.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/istanbul-lib-report/node_modules/make-dir": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^7.5.3"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/istanbul-lib-report/node_modules/semver": {
-            "version": "7.7.1",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/istanbul-lib-source-maps": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^3.0.0",
-                "source-map": "^0.6.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/istanbul-reports": {
-            "version": "3.1.7",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "html-escaper": "^2.0.0",
-                "istanbul-lib-report": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/jackspeak": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "../clingo-wasm/node_modules/jest": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/core": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "import-local": "^3.0.2",
-                "jest-cli": "^29.7.0"
-            },
-            "bin": {
-                "jest": "bin/jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/jest-changed-files": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "execa": "^5.0.0",
-                "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-circus": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/expect": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "co": "^4.6.0",
-                "dedent": "^1.0.0",
-                "is-generator-fn": "^2.0.0",
-                "jest-each": "^29.7.0",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0",
-                "pretty-format": "^29.7.0",
-                "pure-rand": "^6.0.0",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-cli": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/core": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "create-jest": "^29.7.0",
-                "exit": "^0.1.2",
-                "import-local": "^3.0.2",
-                "jest-config": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "yargs": "^17.3.1"
-            },
-            "bin": {
-                "jest": "bin/jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/jest-config": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@jest/test-sequencer": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "babel-jest": "^29.7.0",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "deepmerge": "^4.2.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "jest-circus": "^29.7.0",
-                "jest-environment-node": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-runner": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "parse-json": "^5.2.0",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-json-comments": "^3.1.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@types/node": "*",
-                "ts-node": ">=9.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "ts-node": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/jest-diff": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^29.6.3",
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-docblock": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "detect-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-each": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "jest-get-type": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-environment-node": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "jest-mock": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-get-type": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-haste-map": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/graceful-fs": "^4.1.3",
-                "@types/node": "*",
-                "anymatch": "^3.0.3",
-                "fb-watchman": "^2.0.0",
-                "graceful-fs": "^4.2.9",
-                "jest-regex-util": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "walker": "^1.0.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "^2.3.2"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-leak-detector": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-matcher-utils": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "jest-diff": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-message-util": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.12.13",
-                "@jest/types": "^29.6.3",
-                "@types/stack-utils": "^2.0.0",
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "micromatch": "^4.0.4",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-mock": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-pnp-resolver": {
-            "version": "1.2.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            },
-            "peerDependencies": {
-                "jest-resolve": "*"
-            },
-            "peerDependenciesMeta": {
-                "jest-resolve": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/jest-regex-util": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-resolve": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-pnp-resolver": "^1.2.2",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "resolve": "^1.20.0",
-                "resolve.exports": "^2.0.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-resolve-dependencies": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "jest-regex-util": "^29.6.3",
-                "jest-snapshot": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-runner": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/environment": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "emittery": "^0.13.1",
-                "graceful-fs": "^4.2.9",
-                "jest-docblock": "^29.7.0",
-                "jest-environment-node": "^29.7.0",
-                "jest-haste-map": "^29.7.0",
-                "jest-leak-detector": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-resolve": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-watcher": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "p-limit": "^3.1.0",
-                "source-map-support": "0.5.13"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-runtime": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/globals": "^29.7.0",
-                "@jest/source-map": "^29.6.3",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "cjs-module-lexer": "^1.0.0",
-                "collect-v8-coverage": "^1.0.0",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-mock": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-bom": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-snapshot": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@babel/generator": "^7.7.2",
-                "@babel/plugin-syntax-jsx": "^7.7.2",
-                "@babel/plugin-syntax-typescript": "^7.7.2",
-                "@babel/types": "^7.3.3",
-                "@jest/expect-utils": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "babel-preset-current-node-syntax": "^1.0.0",
-                "chalk": "^4.0.0",
-                "expect": "^29.7.0",
-                "graceful-fs": "^4.2.9",
-                "jest-diff": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^29.7.0",
-                "semver": "^7.5.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-snapshot/node_modules/semver": {
-            "version": "7.7.1",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-util": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "graceful-fs": "^4.2.9",
-                "picomatch": "^2.2.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-validate": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "camelcase": "^6.2.0",
-                "chalk": "^4.0.0",
-                "jest-get-type": "^29.6.3",
-                "leven": "^3.1.0",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-validate/node_modules/camelcase": {
-            "version": "6.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-watcher": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.0.0",
-                "emittery": "^0.13.1",
-                "jest-util": "^29.7.0",
-                "string-length": "^4.0.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-worker": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-util": "^29.7.0",
-                "merge-stream": "^2.0.0",
-                "supports-color": "^8.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/jest-worker/node_modules/supports-color": {
-            "version": "8.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/js-tokens": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "../clingo-wasm/node_modules/jsesc": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/json-parse-even-better-errors": {
-            "version": "2.3.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/json5": {
-            "version": "2.2.3",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "../clingo-wasm/node_modules/kind-of": {
-            "version": "6.0.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/kleur": {
-            "version": "3.0.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/launch-editor": {
-            "version": "2.10.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "picocolors": "^1.0.0",
-                "shell-quote": "^1.8.1"
-            }
-        },
-        "../clingo-wasm/node_modules/leven": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/lines-and-columns": {
-            "version": "1.2.4",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/loader-runner": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.11.5"
-            }
-        },
-        "../clingo-wasm/node_modules/loader-utils": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
-            }
-        },
-        "../clingo-wasm/node_modules/locate-path": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/lodash.debounce": {
-            "version": "4.0.8",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
-        "../clingo-wasm/node_modules/make-dir": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/makeerror": {
-            "version": "1.0.12",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tmpl": "1.0.5"
-            }
-        },
-        "../clingo-wasm/node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "../clingo-wasm/node_modules/media-typer": {
-            "version": "0.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/memfs": {
-            "version": "4.17.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jsonjoy.com/json-pack": "^1.0.3",
-                "@jsonjoy.com/util": "^1.3.0",
-                "tree-dump": "^1.0.1",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            }
-        },
-        "../clingo-wasm/node_modules/merge-descriptors": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/merge-stream": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/merge2": {
-            "version": "1.4.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "../clingo-wasm/node_modules/methods": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/micromatch": {
-            "version": "4.0.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "../clingo-wasm/node_modules/mime": {
-            "version": "1.6.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/mime-db": {
-            "version": "1.53.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/mime-types": {
-            "version": "2.1.35",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/mime-types/node_modules/mime-db": {
-            "version": "1.52.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/minimalistic-assert": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/minimist": {
-            "version": "1.2.8",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/minipass": {
-            "version": "7.1.2",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "../clingo-wasm/node_modules/ms": {
-            "version": "2.1.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/multicast-dns": {
-            "version": "7.2.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dns-packet": "^5.2.2",
-                "thunky": "^1.0.2"
-            },
-            "bin": {
-                "multicast-dns": "cli.js"
-            }
-        },
-        "../clingo-wasm/node_modules/natural-compare": {
-            "version": "1.4.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/negotiator": {
-            "version": "0.6.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/neo-async": {
-            "version": "2.6.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/node-forge": {
-            "version": "1.3.1",
-            "dev": true,
-            "license": "(BSD-3-Clause OR GPL-2.0)",
-            "engines": {
-                "node": ">= 6.13.0"
-            }
-        },
-        "../clingo-wasm/node_modules/node-int64": {
-            "version": "0.4.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/node-releases": {
-            "version": "2.0.19",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/normalize-path": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/object-inspect": {
-            "version": "1.13.4",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/obuf": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/on-finished": {
-            "version": "2.4.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ee-first": "1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/on-headers": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/once": {
-            "version": "1.4.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "../clingo-wasm/node_modules/onetime": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/open": {
-            "version": "10.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "default-browser": "^5.2.1",
-                "define-lazy-prop": "^3.0.0",
-                "is-inside-container": "^1.0.0",
-                "is-wsl": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/open/node_modules/is-wsl": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-inside-container": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/p-limit": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "yocto-queue": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/p-locate": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/p-locate/node_modules/p-limit": {
-            "version": "2.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/p-retry": {
-            "version": "6.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/retry": "0.12.2",
-                "is-network-error": "^1.0.0",
-                "retry": "^0.13.1"
-            },
-            "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/p-try": {
-            "version": "2.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/package-json-from-dist": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
-        },
-        "../clingo-wasm/node_modules/parse-json": {
-            "version": "5.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/parseurl": {
-            "version": "1.3.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/path-exists": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/path-is-inside": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "(WTFPL OR MIT)"
-        },
-        "../clingo-wasm/node_modules/path-key": {
-            "version": "3.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/path-parse": {
-            "version": "1.0.7",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/path-scurry": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "../clingo-wasm/node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.0.2",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "../clingo-wasm/node_modules/path-to-regexp": {
-            "version": "3.3.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/path-type": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/picocolors": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/picomatch": {
-            "version": "2.3.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "../clingo-wasm/node_modules/pirates": {
-            "version": "4.0.6",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "../clingo-wasm/node_modules/pkg-dir": {
-            "version": "4.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "find-up": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/prompts": {
-            "version": "2.4.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.5"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "../clingo-wasm/node_modules/proxy-addr": {
-            "version": "2.0.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "forwarded": "0.2.0",
-                "ipaddr.js": "1.9.1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "../clingo-wasm/node_modules/proxy-addr/node_modules/ipaddr.js": {
-            "version": "1.9.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "../clingo-wasm/node_modules/punycode": {
-            "version": "2.3.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/pure-rand": {
-            "version": "6.1.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/dubzzz"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fast-check"
-                }
-            ],
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/qs": {
-            "version": "6.13.0",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.0.6"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/randombytes": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
-        "../clingo-wasm/node_modules/range-parser": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/raw-body": {
-            "version": "2.5.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/raw-body/node_modules/bytes": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/rc": {
-            "version": "1.2.8",
-            "dev": true,
-            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-            "dependencies": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "bin": {
-                "rc": "cli.js"
-            }
-        },
-        "../clingo-wasm/node_modules/rc/node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/react-is": {
-            "version": "18.3.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "../clingo-wasm/node_modules/readdirp": {
-            "version": "3.6.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
-            "engines": {
-                "node": ">=8.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/rechoir": {
-            "version": "0.8.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "resolve": "^1.20.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            }
-        },
-        "../clingo-wasm/node_modules/regenerate": {
-            "version": "1.4.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/regenerate-unicode-properties": {
-            "version": "10.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "regenerate": "^1.4.2"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/regexpu-core": {
-            "version": "6.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^10.2.0",
-                "regjsgen": "^0.8.0",
-                "regjsparser": "^0.12.0",
-                "unicode-match-property-ecmascript": "^2.0.0",
-                "unicode-match-property-value-ecmascript": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/registry-auth-token": {
-            "version": "3.3.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "rc": "^1.1.6",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "../clingo-wasm/node_modules/registry-url": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "rc": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/regjsgen": {
-            "version": "0.8.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/regjsparser": {
-            "version": "0.12.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "jsesc": "~3.0.2"
-            },
-            "bin": {
-                "regjsparser": "bin/parser"
-            }
-        },
-        "../clingo-wasm/node_modules/regjsparser/node_modules/jsesc": {
-            "version": "3.0.2",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/require-directory": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/require-from-string": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/requires-port": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/resolve": {
-            "version": "1.22.10",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.16.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/resolve-cwd": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/resolve-from": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/resolve.exports": {
-            "version": "2.0.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/retry": {
-            "version": "0.13.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "../clingo-wasm/node_modules/reusify": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/rimraf": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^11.0.0",
-                "package-json-from-dist": "^1.0.0"
-            },
-            "bin": {
-                "rimraf": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "../clingo-wasm/node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/rimraf/node_modules/glob": {
-            "version": "11.0.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^4.0.1",
-                "minimatch": "^10.0.0",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "../clingo-wasm/node_modules/rimraf/node_modules/minimatch": {
-            "version": "10.0.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "../clingo-wasm/node_modules/run-applescript": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/run-parallel": {
-            "version": "1.2.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
-            }
-        },
-        "../clingo-wasm/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/schema-utils": {
-            "version": "3.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.8",
-                "ajv": "^6.12.5",
-                "ajv-keywords": "^3.5.2"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "../clingo-wasm/node_modules/select-hose": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/selfsigned": {
-            "version": "2.4.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node-forge": "^1.3.0",
-                "node-forge": "^1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/semver": {
-            "version": "6.3.1",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "../clingo-wasm/node_modules/send": {
-            "version": "0.19.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/send/node_modules/debug": {
-            "version": "2.6.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/send/node_modules/debug/node_modules/ms": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/send/node_modules/encodeurl": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/send/node_modules/range-parser": {
-            "version": "1.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
-            }
-        },
-        "../clingo-wasm/node_modules/serve": {
-            "version": "14.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@zeit/schemas": "2.36.0",
-                "ajv": "8.12.0",
-                "arg": "5.0.2",
-                "boxen": "7.0.0",
-                "chalk": "5.0.1",
-                "chalk-template": "0.4.0",
-                "clipboardy": "3.0.0",
-                "compression": "1.7.4",
-                "is-port-reachable": "4.0.0",
-                "serve-handler": "6.1.6",
-                "update-check": "1.5.4"
-            },
-            "bin": {
-                "serve": "build/main.js"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "../clingo-wasm/node_modules/serve-handler": {
-            "version": "6.1.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "3.0.0",
-                "content-disposition": "0.5.2",
-                "mime-types": "2.1.18",
-                "minimatch": "3.1.2",
-                "path-is-inside": "1.0.2",
-                "path-to-regexp": "3.3.0",
-                "range-parser": "1.2.0"
-            }
-        },
-        "../clingo-wasm/node_modules/serve-handler/node_modules/mime-db": {
-            "version": "1.33.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/serve-handler/node_modules/mime-types": {
-            "version": "2.1.18",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "~1.33.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/serve-index": {
-            "version": "1.9.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "accepts": "~1.3.4",
-                "batch": "0.6.1",
-                "debug": "2.6.9",
-                "escape-html": "~1.0.3",
-                "http-errors": "~1.6.2",
-                "mime-types": "~2.1.17",
-                "parseurl": "~1.3.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/serve-index/node_modules/debug": {
-            "version": "2.6.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/serve-index/node_modules/depd": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/serve-index/node_modules/http-errors": {
-            "version": "1.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/serve-index/node_modules/inherits": {
-            "version": "2.0.3",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/serve-index/node_modules/ms": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/serve-index/node_modules/setprototypeof": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/serve-index/node_modules/statuses": {
-            "version": "1.5.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/serve-static": {
-            "version": "1.16.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.19.0"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/serve/node_modules/ajv": {
-            "version": "8.12.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "../clingo-wasm/node_modules/serve/node_modules/chalk": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/serve/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/setprototypeof": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/shallow-clone": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kind-of": "^6.0.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/shebang-command": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "shebang-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/shebang-regex": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/shell-quote": {
-            "version": "1.8.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/side-channel": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
-                "side-channel-map": "^1.0.1",
-                "side-channel-weakmap": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/side-channel-map": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/side-channel-weakmap": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.5",
-                "object-inspect": "^1.13.3",
-                "side-channel-map": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/sisteransi": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/slash": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/sockjs": {
-            "version": "0.3.24",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "faye-websocket": "^0.11.3",
-                "uuid": "^8.3.2",
-                "websocket-driver": "^0.7.4"
-            }
-        },
-        "../clingo-wasm/node_modules/source-map": {
-            "version": "0.6.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/source-map-support": {
-            "version": "0.5.13",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
-        },
-        "../clingo-wasm/node_modules/spdy": {
-            "version": "4.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.1.0",
-                "handle-thing": "^2.0.0",
-                "http-deceiver": "^1.2.7",
-                "select-hose": "^2.0.0",
-                "spdy-transport": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/spdy-transport": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.1.0",
-                "detect-node": "^2.0.4",
-                "hpack.js": "^2.1.6",
-                "obuf": "^1.1.2",
-                "readable-stream": "^3.0.6",
-                "wbuf": "^1.7.3"
-            }
-        },
-        "../clingo-wasm/node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
-        "../clingo-wasm/node_modules/stack-utils": {
-            "version": "2.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/statuses": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/string_decoder": {
-            "version": "1.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
-        "../clingo-wasm/node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/string-length": {
-            "version": "4.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "char-regex": "^1.0.2",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/string-width": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/string-width-cjs": {
-            "name": "string-width",
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/string-width-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/string-width/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/string-width/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/strip-ansi-cjs": {
-            "name": "strip-ansi",
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/strip-bom": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/strip-json-comments": {
-            "version": "3.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/strip-outer": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/strip-outer/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/supports-color": {
-            "version": "7.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "../clingo-wasm/node_modules/tapable": {
-            "version": "2.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "../clingo-wasm/node_modules/terser": {
-            "version": "5.39.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.8.2",
-                "commander": "^2.20.0",
-                "source-map-support": "~0.5.20"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/terser-webpack-plugin": {
-            "version": "5.3.14",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jest-worker": "^27.4.5",
-                "schema-utils": "^4.3.0",
-                "serialize-javascript": "^6.0.2",
-                "terser": "^5.31.1"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.1.0"
-            },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "uglify-js": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/ajv": {
-            "version": "8.17.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/jest-worker": {
-            "version": "27.5.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "merge-stream": "^2.0.0",
-                "supports-color": "^8.0.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            }
-        },
-        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/supports-color": {
-            "version": "8.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/terser/node_modules/commander": {
-            "version": "2.20.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/terser/node_modules/source-map-support": {
-            "version": "0.5.21",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
-        },
-        "../clingo-wasm/node_modules/test-exclude": {
-            "version": "6.0.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@istanbuljs/schema": "^0.1.2",
-                "glob": "^7.1.4",
-                "minimatch": "^3.0.4"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/thingies": {
-            "version": "1.21.0",
-            "dev": true,
-            "license": "Unlicense",
-            "engines": {
-                "node": ">=10.18"
-            },
-            "peerDependencies": {
-                "tslib": "^2"
-            }
-        },
-        "../clingo-wasm/node_modules/thunky": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/tmpl": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
-        "../clingo-wasm/node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/toidentifier": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/tree-dump": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
-            }
-        },
-        "../clingo-wasm/node_modules/trim-repeated": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "../clingo-wasm/node_modules/trim-repeated/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/ts-loader": {
-            "version": "9.5.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.1.0",
-                "enhanced-resolve": "^5.0.0",
-                "micromatch": "^4.0.0",
-                "semver": "^7.3.4",
-                "source-map": "^0.7.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "typescript": "*",
-                "webpack": "^5.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/ts-loader/node_modules/semver": {
-            "version": "7.7.1",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/ts-loader/node_modules/source-map": {
-            "version": "0.7.4",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "../clingo-wasm/node_modules/tslib": {
-            "version": "2.8.1",
-            "dev": true,
-            "license": "0BSD"
-        },
-        "../clingo-wasm/node_modules/type-detect": {
-            "version": "4.0.8",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/type-fest": {
-            "version": "0.21.3",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/type-is": {
-            "version": "1.6.18",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "media-typer": "0.3.0",
-                "mime-types": "~2.1.24"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/typescript": {
-            "version": "5.8.3",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
-        "../clingo-wasm/node_modules/undici-types": {
-            "version": "6.21.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/unicode-canonical-property-names-ecmascript": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/unicode-match-property-ecmascript": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "unicode-canonical-property-names-ecmascript": "^2.0.0",
-                "unicode-property-aliases-ecmascript": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/unicode-match-property-value-ecmascript": {
-            "version": "2.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/unicode-property-aliases-ecmascript": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "../clingo-wasm/node_modules/universalify": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/unpipe": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/update-browserslist-db": {
-            "version": "1.1.3",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "escalade": "^3.2.0",
-                "picocolors": "^1.1.1"
-            },
-            "bin": {
-                "update-browserslist-db": "cli.js"
-            },
-            "peerDependencies": {
-                "browserslist": ">= 4.21.0"
-            }
-        },
-        "../clingo-wasm/node_modules/update-check": {
-            "version": "1.5.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "registry-auth-token": "3.3.2",
-                "registry-url": "3.1.0"
-            }
-        },
-        "../clingo-wasm/node_modules/uri-js": {
-            "version": "4.4.1",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "../clingo-wasm/node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/utils-merge": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
-        "../clingo-wasm/node_modules/uuid": {
-            "version": "8.3.2",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
-        "../clingo-wasm/node_modules/v8-to-istanbul": {
-            "version": "9.3.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.12",
-                "@types/istanbul-lib-coverage": "^2.0.1",
-                "convert-source-map": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.12.0"
-            }
-        },
-        "../clingo-wasm/node_modules/vary": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "../clingo-wasm/node_modules/walker": {
-            "version": "1.0.8",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "makeerror": "1.0.12"
-            }
-        },
-        "../clingo-wasm/node_modules/watchpack": {
-            "version": "2.4.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.1.2"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "../clingo-wasm/node_modules/wbuf": {
-            "version": "1.7.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimalistic-assert": "^1.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack": {
-            "version": "5.99.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
-                "@types/json-schema": "^7.0.15",
-                "@webassemblyjs/ast": "^1.14.1",
-                "@webassemblyjs/wasm-edit": "^1.14.1",
-                "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
-                "browserslist": "^4.24.0",
-                "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
-                "es-module-lexer": "^1.2.1",
-                "eslint-scope": "5.1.1",
-                "events": "^3.2.0",
-                "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.11",
-                "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.2.0",
-                "mime-types": "^2.1.27",
-                "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.2",
-                "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.11",
-                "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
-            },
-            "bin": {
-                "webpack": "bin/webpack.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependenciesMeta": {
-                "webpack-cli": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-cli": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@discoveryjs/json-ext": "^0.6.1",
-                "@webpack-cli/configtest": "^3.0.1",
-                "@webpack-cli/info": "^3.0.1",
-                "@webpack-cli/serve": "^3.0.1",
-                "colorette": "^2.0.14",
-                "commander": "^12.1.0",
-                "cross-spawn": "^7.0.3",
-                "envinfo": "^7.14.0",
-                "fastest-levenshtein": "^1.0.12",
-                "import-local": "^3.0.2",
-                "interpret": "^3.1.1",
-                "rechoir": "^0.8.0",
-                "webpack-merge": "^6.0.1"
-            },
-            "bin": {
-                "webpack-cli": "bin/cli.js"
-            },
-            "engines": {
-                "node": ">=18.12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.82.0"
-            },
-            "peerDependenciesMeta": {
-                "webpack-bundle-analyzer": {
-                    "optional": true
-                },
-                "webpack-dev-server": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-cli/node_modules/commander": {
-            "version": "12.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-middleware": {
-            "version": "7.4.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "colorette": "^2.0.10",
-                "memfs": "^4.6.0",
-                "mime-types": "^2.1.31",
-                "on-finished": "^2.4.1",
-                "range-parser": "^1.2.1",
-                "schema-utils": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 18.12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "webpack": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/ajv": {
-            "version": "8.17.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/range-parser": {
-            "version": "1.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/schema-utils": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-server": {
-            "version": "5.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/bonjour": "^3.5.13",
-                "@types/connect-history-api-fallback": "^1.5.4",
-                "@types/express": "^4.17.21",
-                "@types/express-serve-static-core": "^4.17.21",
-                "@types/serve-index": "^1.9.4",
-                "@types/serve-static": "^1.15.5",
-                "@types/sockjs": "^0.3.36",
-                "@types/ws": "^8.5.10",
-                "ansi-html-community": "^0.0.8",
-                "bonjour-service": "^1.2.1",
-                "chokidar": "^3.6.0",
-                "colorette": "^2.0.10",
-                "compression": "^1.7.4",
-                "connect-history-api-fallback": "^2.0.0",
-                "express": "^4.21.2",
-                "graceful-fs": "^4.2.6",
-                "http-proxy-middleware": "^2.0.7",
-                "ipaddr.js": "^2.1.0",
-                "launch-editor": "^2.6.1",
-                "open": "^10.0.3",
-                "p-retry": "^6.2.0",
-                "schema-utils": "^4.2.0",
-                "selfsigned": "^2.4.1",
-                "serve-index": "^1.9.1",
-                "sockjs": "^0.3.24",
-                "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^7.4.2",
-                "ws": "^8.18.0"
-            },
-            "bin": {
-                "webpack-dev-server": "bin/webpack-dev-server.js"
-            },
-            "engines": {
-                "node": ">= 18.12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "webpack": {
-                    "optional": true
-                },
-                "webpack-cli": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
-            "version": "4.19.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/ajv": {
-            "version": "8.17.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/schema-utils": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-merge": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack-sources": {
-            "version": "3.2.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack/node_modules/ajv": {
-            "version": "8.17.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "../clingo-wasm/node_modules/webpack/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/webpack/node_modules/schema-utils": {
-            "version": "4.3.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "../clingo-wasm/node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "http-parser-js": ">=0.5.1",
-                "safe-buffer": ">=5.1.0",
-                "websocket-extensions": ">=0.1.1"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/websocket-extensions": {
-            "version": "0.1.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "../clingo-wasm/node_modules/which": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "../clingo-wasm/node_modules/widest-line": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "string-width": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "../clingo-wasm/node_modules/wildcard": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/worker-loader": {
-            "version": "3.0.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "loader-utils": "^2.0.0",
-                "schema-utils": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/wrap-ansi-cjs": {
-            "name": "wrap-ansi",
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/wrap-ansi-cjs/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "../clingo-wasm/node_modules/wrappy": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/write-file-atomic": {
-            "version": "4.0.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "../clingo-wasm/node_modules/ws": {
-            "version": "8.18.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
-        "../clingo-wasm/node_modules/y18n": {
-            "version": "5.0.8",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "../clingo-wasm/node_modules/yallist": {
-            "version": "3.1.1",
-            "dev": true,
-            "license": "ISC"
-        },
-        "../clingo-wasm/node_modules/yargs": {
-            "version": "17.7.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "../clingo-wasm/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "../clingo-wasm/node_modules/yargs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "../clingo-wasm/node_modules/yargs/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "../clingo-wasm/node_modules/yocto-queue": {
-            "version": "0.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -8614,21 +39,24 @@
         },
         "node_modules/@azu/format-text": {
             "version": "1.0.2",
-            "dev": true,
-            "license": "BSD-3-Clause"
+            "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+            "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
+            "dev": true
         },
         "node_modules/@azu/style-format": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+            "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
             "dev": true,
-            "license": "WTFPL",
             "dependencies": {
                 "@azu/format-text": "^1.0.1"
             }
         },
         "node_modules/@azure/abort-controller": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -8637,22 +65,24 @@
             }
         },
         "node_modules/@azure/core-auth": {
-            "version": "1.9.0",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.0.tgz",
+            "integrity": "sha512-88Djs5vBvGbHQHf5ZZcaoNHo6Y8BKZkt3cw2iuJIQzLEgH4Ox6Tm4hjFhbqOxyYsgIG/eJbFEHpxRIfEEWv5Ow==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-util": "^1.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-client": {
-            "version": "1.9.4",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.0.tgz",
+            "integrity": "sha512-O4aP3CLFNodg8eTHXECaH3B3CjicfzkxVtnrfLkOq0XNP7TIECGfHpK/C6vADZkWP75wzmdBnsIA8ksuJMk18g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.4.0",
@@ -8663,54 +93,58 @@
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.21.0",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.0.tgz",
+            "integrity": "sha512-OKHmb3/Kpm06HypvB3g6Q3zJuvyXcpxDpCS1PnU8OV6AJgSFaee/covXBcPbWc6XDDxtEPlbi3EMQ6nUiPaQtw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.8.0",
                 "@azure/core-tracing": "^1.0.1",
                 "@azure/core-util": "^1.11.0",
                 "@azure/logger": "^1.0.0",
-                "@typespec/ts-http-runtime": "^0.2.3",
+                "@typespec/ts-http-runtime": "^0.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-tracing": {
-            "version": "1.2.0",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.0.tgz",
+            "integrity": "sha512-+XvmZLLWPe67WXNZo9Oc9CrPj/Tm8QnHR92fFAFdnbzwNdCH1h+7UdpaQgRSBsMY+oW1kHXNUZQLdZ1gHX3ROw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-util": {
-            "version": "1.12.0",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.0.tgz",
+            "integrity": "sha512-o0psW8QWQ58fq3i24Q1K2XfS/jYTxr7O1HRcyUE9bV9NttLU+kYOH82Ixj8DGlMTOWgxm1Sss2QAfKK5UkSPxw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
-                "@typespec/ts-http-runtime": "^0.2.2",
+                "@typespec/ts-http-runtime": "^0.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/identity": {
-            "version": "4.10.1",
+            "version": "4.10.2",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.10.2.tgz",
+            "integrity": "sha512-Uth4vz0j+fkXCkbvutChUj03PDCokjbC6Wk9JT8hHEUtpy/EurNKAseb3+gO6Zi9VYBvwt61pgbzn1ovk942Qg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.9.0",
@@ -8725,46 +159,50 @@
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/logger": {
-            "version": "1.2.0",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+            "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@typespec/ts-http-runtime": "^0.2.2",
+                "@typespec/ts-http-runtime": "^0.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/msal-browser": {
-            "version": "4.13.2",
+            "version": "4.16.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.16.0.tgz",
+            "integrity": "sha512-yF8gqyq7tVnYftnrWaNaxWpqhGQXoXpDfwBtL7UCGlIbDMQ1PUJF/T2xCL6NyDNHoO70qp1xU8GjjYTyNIefkw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.7.1"
+                "@azure/msal-common": "15.9.0"
             },
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "15.7.1",
+            "version": "15.9.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.9.0.tgz",
+            "integrity": "sha512-lbz/D+C9ixUG3hiZzBLjU79a0+5ZXCorjel3mwXluisKNH0/rOS/ajm8yi4yI9RP5Uc70CAcs9Ipd0051Oh/kA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "3.6.1",
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.6.4.tgz",
+            "integrity": "sha512-jMeut9UQugcmq7aPWWlJKhJIse4DQ594zc/JaP6BIxg55XaX3aM/jcPuIQ4ryHnI4QSf03wUspy/uqAvjWKbOg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.7.1",
+                "@azure/msal-common": "15.9.0",
                 "jsonwebtoken": "^9.0.0",
                 "uuid": "^8.3.0"
             },
@@ -8773,41 +211,44 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.26.2",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.27.1",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.8",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+            "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.26.10",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+            "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.26.10",
-                "@babel/helper-compilation-targets": "^7.26.5",
-                "@babel/helper-module-transforms": "^7.26.0",
-                "@babel/helpers": "^7.26.10",
-                "@babel/parser": "^7.26.10",
-                "@babel/template": "^7.26.9",
-                "@babel/traverse": "^7.26.10",
-                "@babel/types": "^7.26.10",
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.0",
+                "@babel/helper-compilation-targets": "^7.27.2",
+                "@babel/helper-module-transforms": "^7.27.3",
+                "@babel/helpers": "^7.27.6",
+                "@babel/parser": "^7.28.0",
+                "@babel/template": "^7.27.2",
+                "@babel/traverse": "^7.28.0",
+                "@babel/types": "^7.28.0",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -8824,21 +265,23 @@
         },
         "node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.27.0",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+            "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.27.0",
-                "@babel/types": "^7.27.0",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.28.0",
+                "@babel/types": "^7.28.0",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             },
             "engines": {
@@ -8846,12 +289,13 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.0",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.26.8",
-                "@babel/helper-validator-option": "^7.25.9",
+                "@babel/compat-data": "^7.27.2",
+                "@babel/helper-validator-option": "^7.27.1",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -8860,47 +304,46 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
             "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
-            "version": "3.1.1",
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
             "dev": true,
-            "license": "ISC"
+            "engines": {
+                "node": ">=6.9.0"
+            }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.25.9",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.26.0",
+            "version": "7.27.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+            "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.27.3"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -8910,55 +353,61 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.26.5",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.25.9",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.0",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+            "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0"
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.27.0",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+            "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.0"
+                "@babel/types": "^7.28.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -8969,8 +418,9 @@
         },
         "node_modules/@babel/plugin-syntax-async-generators": {
             "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -8980,8 +430,9 @@
         },
         "node_modules/@babel/plugin-syntax-bigint": {
             "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -8991,8 +442,9 @@
         },
         "node_modules/@babel/plugin-syntax-class-properties": {
             "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.12.13"
             },
@@ -9002,8 +454,9 @@
         },
         "node_modules/@babel/plugin-syntax-class-static-block": {
             "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -9015,11 +468,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.26.0",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+            "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -9030,8 +484,9 @@
         },
         "node_modules/@babel/plugin-syntax-import-meta": {
             "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -9041,8 +496,9 @@
         },
         "node_modules/@babel/plugin-syntax-json-strings": {
             "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -9051,11 +507,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.25.9",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+            "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -9066,8 +523,9 @@
         },
         "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
             "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -9077,8 +535,9 @@
         },
         "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
             "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -9088,8 +547,9 @@
         },
         "node_modules/@babel/plugin-syntax-numeric-separator": {
             "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -9099,8 +559,9 @@
         },
         "node_modules/@babel/plugin-syntax-object-rest-spread": {
             "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -9110,8 +571,9 @@
         },
         "node_modules/@babel/plugin-syntax-optional-catch-binding": {
             "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -9121,8 +583,9 @@
         },
         "node_modules/@babel/plugin-syntax-optional-chaining": {
             "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -9132,8 +595,9 @@
         },
         "node_modules/@babel/plugin-syntax-private-property-in-object": {
             "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -9146,8 +610,9 @@
         },
         "node_modules/@babel/plugin-syntax-top-level-await": {
             "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+            "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -9159,11 +624,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.25.9",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+            "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -9173,50 +639,45 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.27.0",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/parser": "^7.27.0",
-                "@babel/types": "^7.27.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.27.0",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+            "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.27.0",
-                "@babel/parser": "^7.27.0",
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.0",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.28.0",
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.0",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/traverse/node_modules/globals": {
-            "version": "11.12.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@babel/types": {
-            "version": "7.27.0",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -9224,26 +685,30 @@
         },
         "node_modules/@bazel/runfiles": {
             "version": "6.3.1",
-            "dev": true,
-            "license": "Apache-2.0"
+            "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.3.1.tgz",
+            "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
+            "dev": true
         },
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "dev": true
         },
         "node_modules/@isaacs/balanced-match": {
             "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "20 || >=22"
             }
         },
         "node_modules/@isaacs/brace-expansion": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@isaacs/balanced-match": "^4.0.1"
             },
@@ -9253,8 +718,9 @@
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "string-width": "^5.1.2",
                 "string-width-cjs": "npm:string-width@^4.2.0",
@@ -9269,8 +735,9 @@
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
@@ -9282,26 +749,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-            "version": "1.0.10",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
-            "version": "5.3.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -9310,22 +762,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -9335,8 +776,9 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -9349,8 +791,9 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -9358,26 +801,20 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@jest/console": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+            "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -9392,8 +829,9 @@
         },
         "node_modules/@jest/core": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+            "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/console": "^29.7.0",
                 "@jest/reporters": "^29.7.0",
@@ -9438,16 +876,18 @@
         },
         "node_modules/@jest/core/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@jest/core/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -9457,8 +897,9 @@
         },
         "node_modules/@jest/environment": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+            "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/fake-timers": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -9471,8 +912,9 @@
         },
         "node_modules/@jest/expect": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+            "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "expect": "^29.7.0",
                 "jest-snapshot": "^29.7.0"
@@ -9483,8 +925,9 @@
         },
         "node_modules/@jest/expect-utils": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+            "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "jest-get-type": "^29.6.3"
             },
@@ -9494,8 +937,9 @@
         },
         "node_modules/@jest/fake-timers": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+            "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@sinonjs/fake-timers": "^10.0.2",
@@ -9510,8 +954,9 @@
         },
         "node_modules/@jest/globals": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+            "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/expect": "^29.7.0",
@@ -9524,8 +969,9 @@
         },
         "node_modules/@jest/reporters": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+            "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@jest/console": "^29.7.0",
@@ -9566,16 +1012,29 @@
         },
         "node_modules/@jest/reporters/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
+        "node_modules/@jest/reporters/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/@jest/reporters/node_modules/glob": {
             "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -9591,10 +1050,23 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/@jest/reporters/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@jest/reporters/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -9604,8 +1076,9 @@
         },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -9615,8 +1088,9 @@
         },
         "node_modules/@jest/source-map": {
             "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+            "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.18",
                 "callsites": "^3.0.0",
@@ -9628,8 +1102,9 @@
         },
         "node_modules/@jest/test-result": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+            "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/console": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -9642,8 +1117,9 @@
         },
         "node_modules/@jest/test-sequencer": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+            "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/test-result": "^29.7.0",
                 "graceful-fs": "^4.2.9",
@@ -9656,8 +1132,9 @@
         },
         "node_modules/@jest/transform": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+            "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@jest/types": "^29.6.3",
@@ -9681,8 +1158,9 @@
         },
         "node_modules/@jest/types": {
             "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9696,43 +1174,35 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.8",
+            "version": "0.3.12",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+            "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+            "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+            "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
+            "version": "0.3.29",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+            "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -9740,8 +1210,9 @@
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -9752,16 +1223,18 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -9772,26 +1245,29 @@
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/@redhat-developer/locators": {
-            "version": "1.13.0",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@redhat-developer/locators/-/locators-1.15.0.tgz",
+            "integrity": "sha512-xxkCoCQsqiA7IVR5kdNfU3MnuT9QSYDeu0KXrwW59FMCcZpUftz6uiQkqgbB212ASlS3mxVhyYpqJan4zr+XtA==",
             "dev": true,
-            "license": "Apache-2.0",
             "peerDependencies": {
                 "@redhat-developer/page-objects": ">=1.0.0",
                 "selenium-webdriver": ">=4.6.1"
             }
         },
         "node_modules/@redhat-developer/page-objects": {
-            "version": "1.13.0",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@redhat-developer/page-objects/-/page-objects-1.15.0.tgz",
+            "integrity": "sha512-Mfr7rVcFB+J16VzLbbqLF9Yo1W7G2bgjkVv0vPUrlkz1dgYdAjZpaQpjs6dVlRO5Uopt11loYu4SS+wnxPopMw==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "clipboardy": "^4.0.0",
                 "clone-deep": "^4.0.1",
@@ -9804,30 +1280,45 @@
                 "typescript": ">=4.6.2"
             }
         },
+        "node_modules/@redhat-developer/page-objects/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "dev": true
         },
         "node_modules/@secretlint/config-creator": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.1.tgz",
+            "integrity": "sha512-nyuRy8uo2+mXPIRLJ93wizD1HbcdDIsVfgCT01p/zGVFrtvmiL7wqsl4KgZH0QFBM/KRLDLeog3/eaM5ASjtvw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@secretlint/types": "^10.1.1"
+                "@secretlint/types": "^10.2.1"
             },
             "engines": {
                 "node": ">=20.0.0"
             }
         },
         "node_modules/@secretlint/config-loader": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.1.tgz",
+            "integrity": "sha512-ob1PwhuSw/Hc6Y4TA63NWj6o++rZTRJOwPZG82o6tgEURqkrAN44fXH9GIouLsOxKa8fbCRLMeGmSBtJLdSqtw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@secretlint/profiler": "^10.1.1",
-                "@secretlint/resolver": "^10.1.1",
-                "@secretlint/types": "^10.1.1",
+                "@secretlint/profiler": "^10.2.1",
+                "@secretlint/resolver": "^10.2.1",
+                "@secretlint/types": "^10.2.1",
                 "ajv": "^8.17.1",
                 "debug": "^4.4.1",
                 "rc-config-loader": "^4.1.3"
@@ -9837,12 +1328,13 @@
             }
         },
         "node_modules/@secretlint/core": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.1.tgz",
+            "integrity": "sha512-2sPp5IE7pM5Q+f1/NK6nJ49FKuqh+e3fZq5MVbtVjegiD4NMhjcoML1Cg7atCBgXPufhXRHY1DWhIhkGzOx/cw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@secretlint/profiler": "^10.1.1",
-                "@secretlint/types": "^10.1.1",
+                "@secretlint/profiler": "^10.2.1",
+                "@secretlint/types": "^10.2.1",
                 "debug": "^4.4.1",
                 "structured-source": "^4.0.0"
             },
@@ -9851,56 +1343,51 @@
             }
         },
         "node_modules/@secretlint/formatter": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.1.tgz",
+            "integrity": "sha512-0A7ho3j0Y4ysK0mREB3O6FKQtScD4rQgfzuI4Slv9Cut1ynQOI7JXAoIFm4XVzhNcgtmEPeD3pQB206VFphBgQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@secretlint/resolver": "^10.1.1",
-                "@secretlint/types": "^10.1.1",
-                "@textlint/linter-formatter": "^14.8.4",
-                "@textlint/module-interop": "^14.8.4",
-                "@textlint/types": "^14.8.4",
-                "chalk": "^4.1.2",
+                "@secretlint/resolver": "^10.2.1",
+                "@secretlint/types": "^10.2.1",
+                "@textlint/linter-formatter": "^15.2.0",
+                "@textlint/module-interop": "^15.2.0",
+                "@textlint/types": "^15.2.0",
+                "chalk": "^5.4.1",
                 "debug": "^4.4.1",
                 "pluralize": "^8.0.0",
-                "strip-ansi": "^6.0.1",
+                "strip-ansi": "^7.1.0",
                 "table": "^6.9.0",
-                "terminal-link": "^2.1.1"
+                "terminal-link": "^4.0.0"
             },
             "engines": {
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@secretlint/formatter/node_modules/ansi-regex": {
-            "version": "5.0.1",
+        "node_modules/@secretlint/formatter/node_modules/chalk": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@secretlint/formatter/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
-            "engines": {
-                "node": ">=8"
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/@secretlint/node": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.1.tgz",
+            "integrity": "sha512-MQFte7C+5ZHINQGSo6+eUECcUCGvKR9PVgZcTsRj524xsbpeBqF1q1dHsUsdGb9r2jlvf40Q14MRZwMcpmLXWQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@secretlint/config-loader": "^10.1.1",
-                "@secretlint/core": "^10.1.1",
-                "@secretlint/formatter": "^10.1.1",
-                "@secretlint/profiler": "^10.1.1",
-                "@secretlint/source-creator": "^10.1.1",
-                "@secretlint/types": "^10.1.1",
+                "@secretlint/config-loader": "^10.2.1",
+                "@secretlint/core": "^10.2.1",
+                "@secretlint/formatter": "^10.2.1",
+                "@secretlint/profiler": "^10.2.1",
+                "@secretlint/source-creator": "^10.2.1",
+                "@secretlint/types": "^10.2.1",
                 "debug": "^4.4.1",
                 "p-map": "^7.0.3"
             },
@@ -9909,48 +1396,54 @@
             }
         },
         "node_modules/@secretlint/profiler": {
-            "version": "10.1.1",
-            "dev": true,
-            "license": "MIT"
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.1.tgz",
+            "integrity": "sha512-gOlfPZ1ASc5mP5cqsL809uMJGp85t+AJZg1ZPscWvB/m5UFFgeNTZcOawggb1S5ExDvR388sIJxagx5hyDZ34g==",
+            "dev": true
         },
         "node_modules/@secretlint/resolver": {
-            "version": "10.1.1",
-            "dev": true,
-            "license": "MIT"
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.1.tgz",
+            "integrity": "sha512-AuwehKwnE2uxKaJVv2Z5a8FzGezBmlNhtLKm70Cvsvtwd0oAtenxCSTKXkiPGYC0+S91fAw3lrX7CUkyr9cTCA==",
+            "dev": true
         },
         "node_modules/@secretlint/secretlint-formatter-sarif": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.1.tgz",
+            "integrity": "sha512-qOZUYBesLkhCBP7YVMv0l1Pypt8e3V2rX2PT2Q5aJhJvKTcMiP9YTHG/3H9Zb7Gq3UIwZLEAGXRqJOu1XlE0Fg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "node-sarif-builder": "^2.0.3"
+                "node-sarif-builder": "^3.2.0"
             }
         },
         "node_modules/@secretlint/secretlint-rule-no-dotenv": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.1.tgz",
+            "integrity": "sha512-XwPjc9Wwe2QljerfvGlBmLJAJVATLvoXXw1fnKyCDNgvY33cu1Z561Kxg93xfRB5LSep0S5hQrAfZRJw6x7MBQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@secretlint/types": "^10.1.1"
+                "@secretlint/types": "^10.2.1"
             },
             "engines": {
                 "node": ">=20.0.0"
             }
         },
         "node_modules/@secretlint/secretlint-rule-preset-recommend": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.1.tgz",
+            "integrity": "sha512-/kj3UOpFbJt80dqoeEaUVv5nbeW1jPqPExA447FItthiybnaDse5C5HYcfNA2ywEInr399ELdcmpEMRe+ld1iQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=20.0.0"
             }
         },
         "node_modules/@secretlint/source-creator": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.1.tgz",
+            "integrity": "sha512-1CgO+hsRx8KdA5R/LEMNTJkujjomwSQQVV0BcuKynpOefV/rRlIDVQJOU0tJOZdqUMC15oAAwQXs9tMwWLu4JQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@secretlint/types": "^10.1.1",
+                "@secretlint/types": "^10.2.1",
                 "istextorbinary": "^9.5.0"
             },
             "engines": {
@@ -9958,22 +1451,25 @@
             }
         },
         "node_modules/@secretlint/types": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.1.tgz",
+            "integrity": "sha512-F5k1qpoMoUe7rrZossOBgJ3jWKv/FGDBZIwepqnefgPmNienBdInxhtZeXiGwjcxXHVhsdgp6I5Fi/M8PMgwcw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=20.0.0"
             }
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+            "dev": true
         },
         "node_modules/@sindresorhus/is": {
-            "version": "7.0.1",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.0.2.tgz",
+            "integrity": "sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -9983,8 +1479,9 @@
         },
         "node_modules/@sindresorhus/merge-streams": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -9994,24 +1491,27 @@
         },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "type-detect": "4.0.8"
             }
         },
         "node_modules/@sinonjs/fake-timers": {
             "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
             }
         },
         "node_modules/@szmarczak/http-timer": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+            "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "defer-to-connect": "^2.0.1"
             },
@@ -10020,20 +1520,22 @@
             }
         },
         "node_modules/@textlint/ast-node-types": {
-            "version": "14.8.4",
-            "dev": true,
-            "license": "MIT"
+            "version": "15.2.1",
+            "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.2.1.tgz",
+            "integrity": "sha512-20fEcLPsXg81yWpApv4FQxrZmlFF/Ta7/kz1HGIL+pJo5cSTmkc+eCki3GpOPZIoZk0tbJU8hrlwUb91F+3SNQ==",
+            "dev": true
         },
         "node_modules/@textlint/linter-formatter": {
-            "version": "14.8.4",
+            "version": "15.2.1",
+            "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.2.1.tgz",
+            "integrity": "sha512-oollG/BHa07+mMt372amxHohteASC+Zxgollc1sZgiyxo4S6EuureV3a4QIQB0NecA+Ak3d0cl0WI/8nou38jw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@azu/format-text": "^1.0.2",
                 "@azu/style-format": "^1.0.1",
-                "@textlint/module-interop": "14.8.4",
-                "@textlint/resolver": "14.8.4",
-                "@textlint/types": "14.8.4",
+                "@textlint/module-interop": "15.2.1",
+                "@textlint/resolver": "15.2.1",
+                "@textlint/types": "15.2.1",
                 "chalk": "^4.1.2",
                 "debug": "^4.4.1",
                 "js-yaml": "^3.14.1",
@@ -10047,46 +1549,30 @@
         },
         "node_modules/@textlint/linter-formatter/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/@textlint/linter-formatter/node_modules/argparse": {
-            "version": "1.0.10",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "node_modules/@textlint/linter-formatter/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@textlint/linter-formatter/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
             "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+            "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+            "dev": true
         },
         "node_modules/@textlint/linter-formatter/node_modules/string-width": {
             "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -10098,8 +1584,9 @@
         },
         "node_modules/@textlint/linter-formatter/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -10108,35 +1595,40 @@
             }
         },
         "node_modules/@textlint/module-interop": {
-            "version": "14.8.4",
-            "dev": true,
-            "license": "MIT"
+            "version": "15.2.1",
+            "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.2.1.tgz",
+            "integrity": "sha512-b/C/ZNrm05n1ypymDknIcpkBle30V2ZgE3JVqQlA9PnQV46Ky510qrZk6s9yfKgA3m1YRnAw04m8xdVtqjq1qg==",
+            "dev": true
         },
         "node_modules/@textlint/resolver": {
-            "version": "14.8.4",
-            "dev": true,
-            "license": "MIT"
+            "version": "15.2.1",
+            "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.2.1.tgz",
+            "integrity": "sha512-FY3aK4tElEcOJVUsaMj4Zro4jCtKEEwUMIkDL0tcn6ljNcgOF7Em+KskRRk/xowFWayqDtdz5T3u7w/6fjjuJQ==",
+            "dev": true
         },
         "node_modules/@textlint/types": {
-            "version": "14.8.4",
+            "version": "15.2.1",
+            "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.2.1.tgz",
+            "integrity": "sha512-zyqNhSatK1cwxDUgosEEN43hFh3WCty9Zm2Vm3ogU566IYegifwqN54ey/CiRy/DiO4vMcFHykuQnh2Zwp6LLw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@textlint/ast-node-types": "14.8.4"
+                "@textlint/ast-node-types": "15.2.1"
             }
         },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.20.7",
                 "@babel/types": "^7.20.7",
@@ -10146,17 +1638,19 @@
             }
         },
         "node_modules/@types/babel__generator": {
-            "version": "7.6.8",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.0.0"
             }
         },
         "node_modules/@types/babel__template": {
             "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -10164,73 +1658,89 @@
         },
         "node_modules/@types/babel__traverse": {
             "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
+            "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/emscripten": {
+            "version": "1.40.1",
+            "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.40.1.tgz",
+            "integrity": "sha512-sr53lnYkQNhjHNN0oJDdUm5564biioI5DuOpycufDVK7D3y+GR3oUswe2rlwY1nPNyusHbrJ9WoTyIHl4/Bpwg=="
+        },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/http-cache-semantics": {
             "version": "4.0.4",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+            "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+            "dev": true
         },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+            "dev": true
         },
         "node_modules/@types/istanbul-lib-report": {
             "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+            "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/istanbul-lib-coverage": "*"
             }
         },
         "node_modules/@types/istanbul-reports": {
             "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+            "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
         },
         "node_modules/@types/mocha": {
             "version": "10.0.10",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+            "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+            "dev": true
         },
         "node_modules/@types/node": {
-            "version": "22.14.0",
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+            "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.21.0"
+                "undici-types": "~7.8.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.4",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+            "dev": true
         },
         "node_modules/@types/sarif": {
             "version": "2.1.7",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+            "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+            "dev": true
         },
         "node_modules/@types/selenium-webdriver": {
             "version": "4.1.28",
+            "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.1.28.tgz",
+            "integrity": "sha512-Au7CXegiS7oapbB16zxPToY4Cjzi9UQQMf3W2ZZM8PigMLTGR3iUAHjPUTddyE5g1SBjT/qpmvlsAQLBfNAdKg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "@types/ws": "*"
@@ -10238,83 +1748,58 @@
         },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+            "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+            "dev": true
         },
         "node_modules/@types/ws": {
             "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.33",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
         },
         "node_modules/@types/yargs-parser": {
             "version": "21.0.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+            "dev": true
         },
         "node_modules/@typespec/ts-http-runtime": {
-            "version": "0.2.3",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.0.tgz",
+            "integrity": "sha512-sOx1PKSuFwnIl7z4RN0Ls7N9AQawmR9r66eI5rFCzLDIs8HTIYrIpH9QjYWoX0lkgGrkLxXhi4QnK7MizPRrIg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^7.0.0",
                 "https-proxy-agent": "^7.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
-            "version": "7.1.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@typespec/ts-http-runtime/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@vscode/codicons": {
             "version": "0.0.36",
-            "license": "CC-BY-4.0"
+            "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.36.tgz",
+            "integrity": "sha512-wsNOvNMMJ2BY8rC2N2MNBG7yOowV3ov8KlvUE/AiVUlHKTfWsw3OgAOQduX7h0Un6GssKD3aoTVH+TF3DSQwKQ=="
         },
         "node_modules/@vscode/test-cli": {
             "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/@vscode/test-cli/-/test-cli-0.0.11.tgz",
+            "integrity": "sha512-qO332yvzFqGhBMJrp6TdwbIydiHgCtxXc2Nl6M58mbH/Z+0CyLR76Jzv4YWPEthhrARprzCRJUqzFvTHFhTj7Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^10.0.2",
                 "c8": "^9.1.0",
@@ -10333,144 +1818,27 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@vscode/test-cli/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@vscode/test-cli/node_modules/glob": {
-            "version": "10.4.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/test-cli/node_modules/jackspeak": {
-            "version": "3.4.3",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/@vscode/test-cli/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/@vscode/test-cli/node_modules/minimatch": {
-            "version": "9.0.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/test-cli/node_modules/path-scurry": {
-            "version": "1.11.1",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/test-cli/node_modules/supports-color": {
-            "version": "9.4.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
         "node_modules/@vscode/test-electron": {
-            "version": "2.4.1",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+            "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.5",
                 "jszip": "^3.10.1",
-                "ora": "^7.0.1",
+                "ora": "^8.1.0",
                 "semver": "^7.6.2"
             },
             "engines": {
                 "node": ">=16"
             }
         },
-        "node_modules/@vscode/test-electron/node_modules/agent-base": {
-            "version": "7.1.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@vscode/test-electron/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/@vscode/vsce": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.6.0.tgz",
+            "integrity": "sha512-u2ZoMfymRNJb14aHNawnXJtXHLXDVKc1oKZaH4VELKT/9iWKRVgtQOdwxCgtwSxJoqYvuK4hGlBWQJ05wxADhg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.1.0",
                 "@secretlint/node": "^10.1.1",
@@ -10514,9 +1882,10 @@
         },
         "node_modules/@vscode/vsce-sign": {
             "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.6.tgz",
+            "integrity": "sha512-j9Ashk+uOWCDHYDxgGsqzKq5FXW9b9MW7QqOIYZ8IYpneJclWTBeHZz2DJCSKQgo+JAqNcaRRE1hzIx0dswqAw==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
             "optionalDependencies": {
                 "@vscode/vsce-sign-alpine-arm64": "2.0.5",
                 "@vscode/vsce-sign-alpine-x64": "2.0.5",
@@ -10529,40 +1898,245 @@
                 "@vscode/vsce-sign-win32-x64": "2.0.5"
             }
         },
-        "node_modules/@vscode/vsce-sign-win32-x64": {
+        "node_modules/@vscode/vsce-sign-alpine-arm64": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.5.tgz",
+            "integrity": "sha512-XVmnF40APwRPXSLYA28Ye+qWxB25KhSVpF2eZVtVOs6g7fkpOxsVnpRU1Bz2xG4ySI79IRuapDJoAQFkoOgfdQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "alpine"
+            ]
+        },
+        "node_modules/@vscode/vsce-sign-alpine-x64": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.5.tgz",
+            "integrity": "sha512-JuxY3xcquRsOezKq6PEHwCgd1rh1GnhyH6urVEWUzWn1c1PC4EOoyffMD+zLZtFuZF5qR1I0+cqDRNKyPvpK7Q==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "SEE LICENSE IN LICENSE.txt",
+            "optional": true,
+            "os": [
+                "alpine"
+            ]
+        },
+        "node_modules/@vscode/vsce-sign-darwin-arm64": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.5.tgz",
+            "integrity": "sha512-z2Q62bk0ptADFz8a0vtPvnm6vxpyP3hIEYMU+i1AWz263Pj8Mc38cm/4sjzxu+LIsAfhe9HzvYNS49lV+KsatQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@vscode/vsce-sign-darwin-x64": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.5.tgz",
+            "integrity": "sha512-ma9JDC7FJ16SuPXlLKkvOD2qLsmW/cKfqK4zzM2iJE1PbckF3BlR08lYqHV89gmuoTpYB55+z8Y5Fz4wEJBVDA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@vscode/vsce-sign-linux-arm": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.5.tgz",
+            "integrity": "sha512-cdCwtLGmvC1QVrkIsyzv01+o9eR+wodMJUZ9Ak3owhcGxPRB53/WvrDHAFYA6i8Oy232nuen1YqWeEohqBuSzA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vscode/vsce-sign-linux-arm64": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.5.tgz",
+            "integrity": "sha512-Hr1o0veBymg9SmkCqYnfaiUnes5YK6k/lKFA5MhNmiEN5fNqxyPUCdRZMFs3Ajtx2OFW4q3KuYVRwGA7jdLo7Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vscode/vsce-sign-linux-x64": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.5.tgz",
+            "integrity": "sha512-XLT0gfGMcxk6CMRLDkgqEPTyG8Oa0OFe1tPv2RVbphSOjFWJwZgK3TYWx39i/7gqpDHlax0AP6cgMygNJrA6zg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vscode/vsce-sign-win32-arm64": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.5.tgz",
+            "integrity": "sha512-hco8eaoTcvtmuPhavyCZhrk5QIcLiyAUhEso87ApAWDllG7djIrWiOCtqn48k4pHz+L8oCQlE0nwNHfcYcxOPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
             ]
         },
+        "node_modules/@vscode/vsce-sign-win32-x64": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.5.tgz",
+            "integrity": "sha512-1ixKFGM2FwM+6kQS2ojfY3aAelICxjiCzeg4nTHpkeU1Tfs4RC+lVLrgq5NwcBC7ZLr6UfY3Ct3D6suPeOf7BQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/@vscode/vsce/node_modules/commander": {
             "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/agent-base": {
-            "version": "6.0.2",
+        "node_modules/@vscode/vsce/node_modules/glob": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+            "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "debug": "4"
+                "foreground-child": "^3.3.1",
+                "jackspeak": "^4.1.1",
+                "minimatch": "^10.0.3",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
             },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+            "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+            "dev": true,
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/jackspeak": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+            "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+            "dev": true,
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/lru-cache": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+            "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+            "dev": true,
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@vscode/vsce/node_modules/path-scurry": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
             "version": "8.17.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -10576,8 +2150,9 @@
         },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -10588,21 +2163,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "0.21.3",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/ansi-regex": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -10612,8 +2177,9 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -10626,8 +2192,9 @@
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -10637,27 +2204,49 @@
             }
         },
         "node_modules/argparse": {
-            "version": "2.0.1",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
-            "license": "Python-2.0"
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
             "dev": true,
-            "license": "MIT"
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/azure-devops-node-api": {
             "version": "12.5.0",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+            "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",
                 "typed-rest-client": "^1.8.4"
@@ -10665,8 +2254,9 @@
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+            "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/transform": "^29.7.0",
                 "@types/babel__core": "^7.1.14",
@@ -10685,8 +2275,9 @@
         },
         "node_modules/babel-plugin-istanbul": {
             "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+            "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -10700,8 +2291,9 @@
         },
         "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
             "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+            "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "@babel/core": "^7.12.3",
                 "@babel/parser": "^7.14.7",
@@ -10715,16 +2307,18 @@
         },
         "node_modules/babel-plugin-istanbul/node_modules/semver": {
             "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/babel-plugin-jest-hoist": {
             "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+            "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.3.3",
                 "@babel/types": "^7.3.3",
@@ -10737,8 +2331,9 @@
         },
         "node_modules/babel-preset-current-node-syntax": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+            "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
                 "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -10762,8 +2357,9 @@
         },
         "node_modules/babel-preset-jest": {
             "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+            "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "babel-plugin-jest-hoist": "^29.6.3",
                 "babel-preset-current-node-syntax": "^1.0.0"
@@ -10777,11 +2373,14 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true,
             "funding": [
                 {
@@ -10797,29 +2396,35 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT"
+            "optional": true
         },
         "node_modules/big-integer": {
             "version": "1.6.52",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+            "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
             "dev": true,
-            "license": "Unlicense",
             "engines": {
                 "node": ">=0.6"
             }
         },
         "node_modules/binary": {
             "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -10829,8 +2434,9 @@
         },
         "node_modules/binaryextensions": {
             "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+            "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
             "dev": true,
-            "license": "Artistic-2.0",
             "dependencies": {
                 "editions": "^6.21.0"
             },
@@ -10842,19 +2448,23 @@
             }
         },
         "node_modules/bl": {
-            "version": "5.1.0",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "dev": true,
-            "license": "MIT",
+            "optional": true,
             "dependencies": {
-                "buffer": "^6.0.3",
+                "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
             }
         },
         "node_modules/bl/node_modules/readable-stream": {
             "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
-            "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -10865,34 +2475,37 @@
             }
         },
         "node_modules/bluebird": {
-            "version": "3.4.7",
-            "dev": true,
-            "license": "MIT"
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+            "dev": true
         },
         "node_modules/boundary": {
             "version": "2.0.0",
-            "dev": true,
-            "license": "BSD-2-Clause"
+            "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+            "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+            "dev": true
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/braces": {
             "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -10902,11 +2515,14 @@
         },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
         },
         "node_modules/browserslist": {
-            "version": "4.24.4",
+            "version": "4.25.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+            "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
             "dev": true,
             "funding": [
                 {
@@ -10922,12 +2538,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001688",
-                "electron-to-chromium": "^1.5.73",
+                "caniuse-lite": "^1.0.30001726",
+                "electron-to-chromium": "^1.5.173",
                 "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.1"
+                "update-browserslist-db": "^1.1.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -10938,14 +2553,17 @@
         },
         "node_modules/bser": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "node-int64": "^0.4.0"
             }
         },
         "node_modules/buffer": {
-            "version": "6.0.3",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "dev": true,
             "funding": [
                 {
@@ -10961,16 +2579,17 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/buffer-alloc": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "buffer-alloc-unsafe": "^1.1.0",
                 "buffer-fill": "^1.0.0"
@@ -10978,42 +2597,50 @@
         },
         "node_modules/buffer-alloc-unsafe": {
             "version": "1.1.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+            "dev": true
         },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
-            "dev": true,
-            "license": "BSD-3-Clause"
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+            "dev": true
         },
         "node_modules/buffer-fill": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+            "dev": true
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
         },
         "node_modules/buffer-indexof-polyfill": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10"
             }
         },
         "node_modules/buffers": {
             "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
             "dev": true,
             "engines": {
                 "node": ">=0.2.0"
@@ -11021,8 +2648,9 @@
         },
         "node_modules/bundle-name": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "run-applescript": "^7.0.0"
             },
@@ -11035,8 +2663,9 @@
         },
         "node_modules/c8": {
             "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
+            "integrity": "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@istanbuljs/schema": "^0.1.3",
@@ -11059,16 +2688,18 @@
         },
         "node_modules/cacheable-lookup": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             }
         },
         "node_modules/cacheable-request": {
             "version": "12.0.1",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-12.0.1.tgz",
+            "integrity": "sha512-Yo9wGIQUaAfIbk+qY0X4cDQgCosecfBe3V9NSyeY4qPC2SAkbCS4Xj79VP8WOzitpJUZKc/wsRCYF5ariDIwkg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/http-cache-semantics": "^4.0.4",
                 "get-stream": "^9.0.1",
@@ -11084,8 +2715,9 @@
         },
         "node_modules/cacheable-request/node_modules/get-stream": {
             "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@sec-ant/readable-stream": "^0.4.1",
                 "is-stream": "^4.0.1"
@@ -11099,8 +2731,9 @@
         },
         "node_modules/cacheable-request/node_modules/is-stream": {
             "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -11108,10 +2741,29 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/call-bind": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+            "dev": true,
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.0",
+                "es-define-property": "^1.0.0",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2"
@@ -11122,8 +2774,9 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "get-intrinsic": "^1.3.0"
@@ -11137,25 +2790,26 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/camelcase": {
-            "version": "6.3.0",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=6"
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001707",
+            "version": "1.0.30001727",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+            "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
             "dev": true,
             "funding": [
                 {
@@ -11170,21 +2824,25 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ],
-            "license": "CC-BY-4.0"
+            ]
         },
         "node_modules/chainsaw": {
             "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
             "dev": true,
-            "license": "MIT/X11",
             "dependencies": {
                 "traverse": ">=0.3.0 <0.4"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/chalk": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -11196,33 +2854,47 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/char-regex": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/cheerio": {
-            "version": "1.1.0",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+            "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cheerio-select": "^2.1.0",
                 "dom-serializer": "^2.0.0",
                 "domhandler": "^5.0.3",
                 "domutils": "^3.2.2",
-                "encoding-sniffer": "^0.2.0",
+                "encoding-sniffer": "^0.2.1",
                 "htmlparser2": "^10.0.0",
                 "parse5": "^7.3.0",
                 "parse5-htmlparser2-tree-adapter": "^7.1.0",
                 "parse5-parser-stream": "^7.1.2",
-                "undici": "^7.10.0",
+                "undici": "^7.12.0",
                 "whatwg-mimetype": "^4.0.0"
             },
             "engines": {
-                "node": ">=18.17"
+                "node": ">=20.18.1"
             },
             "funding": {
                 "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -11230,8 +2902,9 @@
         },
         "node_modules/cheerio-select": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+            "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-select": "^5.1.0",
@@ -11246,8 +2919,9 @@
         },
         "node_modules/chokidar": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -11269,11 +2943,14 @@
         },
         "node_modules/chownr": {
             "version": "1.1.4",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "dev": true
         },
         "node_modules/ci-info": {
             "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
             "dev": true,
             "funding": [
                 {
@@ -11281,25 +2958,26 @@
                     "url": "https://github.com/sponsors/sibiraj-s"
                 }
             ],
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/cjs-module-lexer": {
             "version": "1.4.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "dev": true
         },
         "node_modules/cli-cursor": {
-            "version": "4.0.0",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "restore-cursor": "^4.0.0"
+                "restore-cursor": "^5.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -11307,8 +2985,9 @@
         },
         "node_modules/cli-spinners": {
             "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             },
@@ -11317,13 +2996,18 @@
             }
         },
         "node_modules/clingo-wasm": {
-            "resolved": "../clingo-wasm",
-            "link": true
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/clingo-wasm/-/clingo-wasm-0.3.2.tgz",
+            "integrity": "sha512-0ZdaGgekZaO8hLF3PE0fcs4FjR+GAdVeMTTzVgm8L1OuCl4A8+/H1V8urBMJYlV6+HH+gAweDxFq1MVgM4lDKQ==",
+            "dependencies": {
+                "@types/emscripten": "^1.40.0"
+            }
         },
         "node_modules/clipboardy": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
+            "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "execa": "^8.0.1",
                 "is-wsl": "^3.1.0",
@@ -11336,655 +3020,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/cliui": {
+        "node_modules/clipboardy/node_modules/execa": {
             "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
             "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/cliui/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/clone-deep": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-plain-object": "^2.0.4",
-                "kind-of": "^6.0.2",
-                "shallow-clone": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/co": {
-            "version": "4.6.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">= 1.0.0",
-                "node": ">= 0.12.0"
-            }
-        },
-        "node_modules/cockatiel": {
-            "version": "3.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/collect-v8-coverage": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/color-convert": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/color-name": {
-            "version": "1.1.4",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/commander": {
-            "version": "14.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/compare-versions": {
-            "version": "6.1.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/create-jest": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
-                "jest-config": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "prompts": "^2.0.1"
-            },
-            "bin": {
-                "create-jest": "bin/create-jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/cross-spawn": {
-            "version": "7.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/cross-spawn/node_modules/isexe": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/cross-spawn/node_modules/which": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/css-select": {
-            "version": "5.2.2",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "boolbase": "^1.0.0",
-                "css-what": "^6.1.0",
-                "domhandler": "^5.0.2",
-                "domutils": "^3.0.1",
-                "nth-check": "^2.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/css-what": {
-            "version": "6.2.2",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">= 6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/debug": {
-            "version": "4.4.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/decamelize": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/decompress-response/node_modules/mimic-response": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/dedent": {
-            "version": "1.5.3",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "babel-plugin-macros": "^3.1.0"
-            },
-            "peerDependenciesMeta": {
-                "babel-plugin-macros": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/deep-extend": {
-            "version": "0.6.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/deepmerge": {
-            "version": "4.3.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/default-browser": {
-            "version": "5.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bundle-name": "^4.1.0",
-                "default-browser-id": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser-id": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/defer-to-connect": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/define-lazy-prop": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/detect-libc": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/detect-newline": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/diff": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/diff-sequences": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/dom-serializer": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/domelementtype": {
-            "version": "2.3.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/domhandler": {
-            "version": "5.0.3",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "domelementtype": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/domutils": {
-            "version": "3.2.2",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/duplexer2": {
-            "version": "0.1.4",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "readable-stream": "^2.0.2"
-            }
-        },
-        "node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/ecdsa-sig-formatter": {
-            "version": "1.0.11",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/editions": {
-            "version": "6.21.0",
-            "dev": true,
-            "license": "Artistic-2.0",
-            "dependencies": {
-                "version-range": "^4.13.0"
-            },
-            "engines": {
-                "node": ">=4"
-            },
-            "funding": {
-                "url": "https://bevry.me/fund"
-            }
-        },
-        "node_modules/electron-to-chromium": {
-            "version": "1.5.129",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/emittery": {
-            "version": "0.13.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-            }
-        },
-        "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/encoding-sniffer": {
-            "version": "0.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "iconv-lite": "^0.6.3",
-                "whatwg-encoding": "^3.1.1"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-            }
-        },
-        "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
-        "node_modules/enhanced-resolve": {
-            "version": "5.18.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/entities": {
-            "version": "4.5.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/error-ex": {
-            "version": "1.3.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-arrayish": "^0.2.1"
-            }
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/escalade": {
-            "version": "3.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/execa": {
-            "version": "8.0.1",
-            "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^8.0.1",
@@ -12003,10 +3043,44 @@
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
-        "node_modules/execa/node_modules/mimic-fn": {
-            "version": "4.0.0",
+        "node_modules/clipboardy/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
             "dev": true,
-            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/clipboardy/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "node_modules/clipboardy/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/clipboardy/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12014,10 +3088,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/execa/node_modules/onetime": {
-            "version": "6.0.0",
+        "node_modules/clipboardy/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
             "dev": true,
-            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/clipboardy/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
             "dependencies": {
                 "mimic-fn": "^4.0.0"
             },
@@ -12028,8 +3118,801 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/clipboardy/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/clipboardy/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "dev": true,
+            "dependencies": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+            "dev": true,
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/cockatiel": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+            "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/collect-v8-coverage": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+            "dev": true
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/commander": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+            "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+            "dev": true,
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/compare-versions": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+            "dev": true
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
+        },
+        "node_modules/create-jest": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+            "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.9",
+                "jest-config": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "prompts": "^2.0.1"
+            },
+            "bin": {
+                "create-jest": "bin/create-jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cross-spawn/node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
+        },
+        "node_modules/cross-spawn/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/css-select": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+            "dev": true,
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decompress-response": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "dev": true,
+            "dependencies": {
+                "mimic-response": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decompress-response/node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dedent": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+            "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+            "dev": true,
+            "peerDependencies": {
+                "babel-plugin-macros": "^3.1.0"
+            },
+            "peerDependenciesMeta": {
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/default-browser": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+            "dev": true,
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/defer-to-connect": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+            "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/detect-newline": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/diff": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/diff-sequences": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+            "dev": true,
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ]
+        },
+        "node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "dev": true,
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/editions": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/editions/-/editions-6.21.0.tgz",
+            "integrity": "sha512-ofkXJtn7z0urokN62DI3SBo/5xAtF0rR7tn+S/bSYV79Ka8pTajIIl+fFQ1q88DQEImymmo97M4azY3WX/nUdg==",
+            "dev": true,
+            "dependencies": {
+                "version-range": "^4.13.0"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.190",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.190.tgz",
+            "integrity": "sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==",
+            "dev": true
+        },
+        "node_modules/emittery": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+            "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true
+        },
+        "node_modules/encoding-sniffer": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+            "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+            "dev": true,
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "whatwg-encoding": "^3.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+            }
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.4.0"
+            }
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.18.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
+            "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/execa/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true
+        },
         "node_modules/exit": {
             "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
@@ -12037,8 +3920,9 @@
         },
         "node_modules/expand-template": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
             "dev": true,
-            "license": "(MIT OR WTFPL)",
             "optional": true,
             "engines": {
                 "node": ">=6"
@@ -12046,8 +3930,9 @@
         },
         "node_modules/expect": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+            "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/expect-utils": "^29.7.0",
                 "jest-get-type": "^29.6.3",
@@ -12061,12 +3946,14 @@
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -12080,11 +3967,14 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "node_modules/fast-uri": {
             "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
             "funding": [
                 {
                     "type": "github",
@@ -12094,37 +3984,40 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fastify"
                 }
-            ],
-            "license": "BSD-3-Clause"
+            ]
         },
         "node_modules/fastq": {
             "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
             }
         },
         "node_modules/fb-watchman": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+            "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "bser": "2.1.1"
             }
         },
         "node_modules/fd-slicer": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
             }
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -12134,8 +4027,9 @@
         },
         "node_modules/find-up": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -12149,16 +4043,33 @@
         },
         "node_modules/flat": {
             "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "bin": {
                 "flat": "cli.js"
             }
         },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "dev": true,
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/foreground-child": {
             "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "cross-spawn": "^7.0.6",
                 "signal-exit": "^4.0.1"
@@ -12187,22 +4098,25 @@
             }
         },
         "node_modules/form-data-encoder": {
-            "version": "4.0.2",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+            "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true
         },
         "node_modules/fs-extra": {
             "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -12214,13 +4128,30 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
-            "license": "ISC"
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/fstream": {
             "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "deprecated": "This package is no longer supported.",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -12231,10 +4162,22 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/fstream/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/fstream/node_modules/glob": {
             "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -12250,10 +4193,24 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/fstream/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/fstream/node_modules/rimraf": {
             "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -12263,32 +4220,48 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/get-east-asian-width": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+            "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
@@ -12310,16 +4283,18 @@
         },
         "node_modules/get-package-type": {
             "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
             }
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -12329,11 +4304,12 @@
             }
         },
         "node_modules/get-stream": {
-            "version": "8.0.1",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -12341,27 +4317,26 @@
         },
         "node_modules/github-from-package": {
             "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
             "dev": true,
-            "license": "MIT",
             "optional": true
         },
         "node_modules/glob": {
-            "version": "11.0.3",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "foreground-child": "^3.3.1",
-                "jackspeak": "^4.1.1",
-                "minimatch": "^10.0.3",
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
                 "minipass": "^7.1.2",
                 "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -12369,8 +4344,9 @@
         },
         "node_modules/glob-parent": {
             "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -12378,24 +4354,11 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "10.0.3",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@isaacs/brace-expansion": "^5.0.0"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/globby": {
             "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+            "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/merge-streams": "^2.1.0",
                 "fast-glob": "^3.3.3",
@@ -12413,8 +4376,9 @@
         },
         "node_modules/globby/node_modules/slash": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             },
@@ -12422,21 +4386,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/globby/node_modules/unicorn-magic": {
-            "version": "0.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/gopd": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -12446,8 +4400,9 @@
         },
         "node_modules/got": {
             "version": "14.4.7",
+            "resolved": "https://registry.npmjs.org/got/-/got-14.4.7.tgz",
+            "integrity": "sha512-DI8zV1231tqiGzOiOzQWDhsBmncFW7oQDH6Zgy6pDPrqJuVZMtoSgPLLsBZQj8Jg4JFfwoOsDA8NGtLQLnIx2g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/is": "^7.0.1",
                 "@szmarczak/http-timer": "^5.0.1",
@@ -12468,23 +4423,50 @@
                 "url": "https://github.com/sindresorhus/got?sponsor=1"
             }
         },
+        "node_modules/got/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/has-symbols": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -12494,8 +4476,9 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -12508,8 +4491,9 @@
         },
         "node_modules/hasown": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -12519,16 +4503,18 @@
         },
         "node_modules/he": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "he": "bin/he"
             }
         },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -12536,21 +4522,43 @@
                 "node": ">=10"
             }
         },
+        "node_modules/hosted-git-info/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/hosted-git-info/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
+        },
         "node_modules/hpagent": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+            "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/html-escaper": {
             "version": "2.0.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true
         },
         "node_modules/htmlparser2": {
             "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+            "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
             "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -12559,7 +4567,6 @@
                     "url": "https://github.com/sponsors/fb55"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.3",
@@ -12569,8 +4576,9 @@
         },
         "node_modules/htmlparser2/node_modules/entities": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -12579,27 +4587,29 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.1",
-            "dev": true,
-            "license": "BSD-2-Clause"
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "dev": true
         },
         "node_modules/http-proxy-agent": {
-            "version": "4.0.1",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/http2-wrapper": {
             "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "quick-lru": "^5.1.1",
                 "resolve-alpn": "^1.2.0"
@@ -12609,29 +4619,32 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "agent-base": "6",
+                "agent-base": "^7.1.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
-            "version": "5.0.0",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
-                "node": ">=16.17.0"
+                "node": ">=10.17.0"
             }
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -12641,6 +4654,8 @@
         },
         "node_modules/ieee754": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "dev": true,
             "funding": [
                 {
@@ -12656,25 +4671,28 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "BSD-3-Clause"
+            "optional": true
         },
         "node_modules/ignore": {
             "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
         },
         "node_modules/immediate": {
             "version": "3.0.6",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "dev": true
         },
         "node_modules/import-local": {
             "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+            "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "pkg-dir": "^4.2.0",
                 "resolve-cwd": "^3.0.0"
@@ -12691,16 +4709,31 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/index-to-position": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
+            "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -12708,24 +4741,28 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "node_modules/ini": {
             "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true,
-            "license": "ISC",
             "optional": true
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -12733,10 +4770,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -12749,8 +4799,9 @@
         },
         "node_modules/is-docker": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -12763,32 +4814,36 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/is-generator-fn": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -12798,8 +4853,9 @@
         },
         "node_modules/is-inside-container": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-docker": "^3.0.0"
             },
@@ -12815,8 +4871,9 @@
         },
         "node_modules/is-interactive": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -12826,24 +4883,27 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
             }
         },
         "node_modules/is-plain-obj": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/is-plain-object": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "isobject": "^3.0.1"
             },
@@ -12852,20 +4912,37 @@
             }
         },
         "node_modules/is-stream": {
-            "version": "3.0.0",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "dev": true,
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -12875,8 +4952,9 @@
         },
         "node_modules/is-wsl": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-inside-container": "^1.0.0"
             },
@@ -12889,8 +4967,9 @@
         },
         "node_modules/is64bit": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
+            "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "system-architecture": "^0.1.0"
             },
@@ -12903,36 +4982,41 @@
         },
         "node_modules/isarray": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "3.1.1",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+            "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/isobject": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/istanbul-lib-instrument": {
             "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+            "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "@babel/core": "^7.23.9",
                 "@babel/parser": "^7.23.9",
@@ -12946,8 +5030,9 @@
         },
         "node_modules/istanbul-lib-report": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "istanbul-lib-coverage": "^3.0.0",
                 "make-dir": "^4.0.0",
@@ -12957,10 +5042,23 @@
                 "node": ">=10"
             }
         },
+        "node_modules/istanbul-lib-report/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/istanbul-lib-source-maps": {
             "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+            "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "debug": "^4.1.1",
                 "istanbul-lib-coverage": "^3.0.0",
@@ -12972,8 +5070,9 @@
         },
         "node_modules/istanbul-reports": {
             "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+            "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
@@ -12984,8 +5083,9 @@
         },
         "node_modules/istextorbinary": {
             "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+            "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
             "dev": true,
-            "license": "Artistic-2.0",
             "dependencies": {
                 "binaryextensions": "^6.11.0",
                 "editions": "^6.21.0",
@@ -12999,23 +5099,25 @@
             }
         },
         "node_modules/jackspeak": {
-            "version": "4.1.1",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
-            "engines": {
-                "node": "20 || >=22"
-            },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
             }
         },
         "node_modules/jest": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+            "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -13039,8 +5141,9 @@
         },
         "node_modules/jest-changed-files": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+            "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "execa": "^5.0.0",
                 "jest-util": "^29.7.0",
@@ -13050,86 +5153,11 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-changed-files/node_modules/execa": {
-            "version": "5.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/jest-changed-files/node_modules/get-stream": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/jest-changed-files/node_modules/human-signals": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.17.0"
-            }
-        },
-        "node_modules/jest-changed-files/node_modules/is-stream": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/jest-changed-files/node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/jest-changed-files/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/jest-changed-files/node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/jest-circus": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+            "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/expect": "^29.7.0",
@@ -13158,8 +5186,9 @@
         },
         "node_modules/jest-cli": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+            "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/test-result": "^29.7.0",
@@ -13190,8 +5219,9 @@
         },
         "node_modules/jest-config": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+            "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@jest/test-sequencer": "^29.7.0",
@@ -13232,10 +5262,22 @@
                 }
             }
         },
+        "node_modules/jest-config/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/jest-config/node_modules/glob": {
             "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -13251,10 +5293,23 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/jest-config/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/jest-diff": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+            "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.0.0",
                 "diff-sequences": "^29.6.3",
@@ -13267,8 +5322,9 @@
         },
         "node_modules/jest-docblock": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+            "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "detect-newline": "^3.0.0"
             },
@@ -13278,8 +5334,9 @@
         },
         "node_modules/jest-each": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+            "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "chalk": "^4.0.0",
@@ -13293,8 +5350,9 @@
         },
         "node_modules/jest-environment-node": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+            "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -13309,16 +5367,18 @@
         },
         "node_modules/jest-get-type": {
             "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+            "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-haste-map": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+            "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/graceful-fs": "^4.1.3",
@@ -13341,8 +5401,9 @@
         },
         "node_modules/jest-leak-detector": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+            "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "jest-get-type": "^29.6.3",
                 "pretty-format": "^29.7.0"
@@ -13353,8 +5414,9 @@
         },
         "node_modules/jest-matcher-utils": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+            "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.0.0",
                 "jest-diff": "^29.7.0",
@@ -13367,8 +5429,9 @@
         },
         "node_modules/jest-message-util": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+            "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@jest/types": "^29.6.3",
@@ -13386,8 +5449,9 @@
         },
         "node_modules/jest-mock": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+            "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -13399,8 +5463,9 @@
         },
         "node_modules/jest-pnp-resolver": {
             "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             },
@@ -13415,16 +5480,18 @@
         },
         "node_modules/jest-regex-util": {
             "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+            "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-resolve": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+            "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
@@ -13442,8 +5509,9 @@
         },
         "node_modules/jest-resolve-dependencies": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+            "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "jest-regex-util": "^29.6.3",
                 "jest-snapshot": "^29.7.0"
@@ -13454,8 +5522,9 @@
         },
         "node_modules/jest-runner": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+            "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/console": "^29.7.0",
                 "@jest/environment": "^29.7.0",
@@ -13485,8 +5554,9 @@
         },
         "node_modules/jest-runtime": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+            "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -13515,10 +5585,22 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-runtime/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/jest-runtime/node_modules/glob": {
             "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -13534,10 +5616,23 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/jest-runtime/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/jest-snapshot": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+            "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@babel/generator": "^7.7.2",
@@ -13566,8 +5661,9 @@
         },
         "node_modules/jest-util": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+            "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -13582,8 +5678,9 @@
         },
         "node_modules/jest-validate": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+            "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "camelcase": "^6.2.0",
@@ -13596,10 +5693,23 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-validate/node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/jest-watcher": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+            "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/test-result": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -13616,8 +5726,9 @@
         },
         "node_modules/jest-worker": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "jest-util": "^29.7.0",
@@ -13630,8 +5741,9 @@
         },
         "node_modules/jest-worker/node_modules/supports-color": {
             "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -13644,15 +5756,18 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "argparse": "^2.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
@@ -13660,8 +5775,9 @@
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -13671,22 +5787,26 @@
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/json5": {
             "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -13696,13 +5816,15 @@
         },
         "node_modules/jsonc-parser": {
             "version": "3.3.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+            "dev": true
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
             },
@@ -13712,8 +5834,9 @@
         },
         "node_modules/jsonwebtoken": {
             "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "jws": "^3.2.2",
                 "lodash.includes": "^4.3.0",
@@ -13733,8 +5856,9 @@
         },
         "node_modules/jszip": {
             "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
             "dev": true,
-            "license": "(MIT OR GPL-3.0-or-later)",
             "dependencies": {
                 "lie": "~3.3.0",
                 "pako": "~1.0.2",
@@ -13744,8 +5868,9 @@
         },
         "node_modules/jwa": {
             "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+            "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "buffer-equal-constant-time": "^1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -13754,8 +5879,9 @@
         },
         "node_modules/jws": {
             "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
@@ -13763,9 +5889,10 @@
         },
         "node_modules/keytar": {
             "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+            "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "node-addon-api": "^4.3.0",
@@ -13774,66 +5901,75 @@
         },
         "node_modules/keyv": {
             "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/kleur": {
             "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/leven": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/lie": {
             "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "immediate": "~3.0.5"
             }
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true
         },
         "node_modules/linkify-it": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
             }
         },
         "node_modules/listenercount": {
             "version": "1.0.1",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -13846,53 +5982,63 @@
         },
         "node_modules/lodash": {
             "version": "4.17.21",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+            "dev": true
         },
         "node_modules/lodash.isboolean": {
             "version": "3.0.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+            "dev": true
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+            "dev": true
         },
         "node_modules/lodash.isnumber": {
             "version": "3.0.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+            "dev": true
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true
         },
         "node_modules/lodash.isstring": {
             "version": "4.0.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "dev": true
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "dev": true
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+            "dev": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
@@ -13906,8 +6052,9 @@
         },
         "node_modules/lowercase-keys": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -13916,20 +6063,19 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "6.0.0",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
+                "yallist": "^3.0.2"
             }
         },
         "node_modules/make-dir": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "semver": "^7.5.3"
             },
@@ -13942,16 +6088,18 @@
         },
         "node_modules/makeerror": {
             "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+            "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "tmpl": "1.0.5"
             }
         },
         "node_modules/markdown-it": {
             "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -13964,36 +6112,47 @@
                 "markdown-it": "bin/markdown-it.mjs"
             }
         },
+        "node_modules/markdown-it/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/mdurl": {
             "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "dev": true
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -14004,8 +6163,9 @@
         },
         "node_modules/mime": {
             "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "mime": "cli.js"
             },
@@ -14015,16 +6175,18 @@
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
             "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -14034,16 +6196,30 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/mimic-response": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -14052,36 +6228,43 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": "*"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minimist": {
             "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/minipass": {
             "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/mkdirp": {
             "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.6"
             },
@@ -14091,14 +6274,16 @@
         },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true,
-            "license": "MIT",
             "optional": true
         },
         "node_modules/mocha": {
-            "version": "11.5.0",
+            "version": "11.7.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
+            "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "browser-stdout": "^1.3.1",
                 "chokidar": "^4.0.1",
@@ -14116,7 +6301,7 @@
                 "serialize-javascript": "^6.0.2",
                 "strip-json-comments": "^3.1.1",
                 "supports-color": "^8.1.1",
-                "workerpool": "^6.5.1",
+                "workerpool": "^9.2.0",
                 "yargs": "^17.7.2",
                 "yargs-parser": "^21.1.1",
                 "yargs-unparser": "^2.0.0"
@@ -14129,19 +6314,17 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
+        "node_modules/mocha/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
         },
         "node_modules/mocha/node_modules/chokidar": {
             "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "readdirp": "^4.0.1"
             },
@@ -14152,77 +6335,23 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/mocha/node_modules/glob": {
-            "version": "10.4.5",
+        "node_modules/mocha/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
+                "argparse": "^2.0.1"
             },
             "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/jackspeak": {
-            "version": "3.4.3",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/mocha/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/mocha/node_modules/minimatch": {
-            "version": "9.0.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/path-scurry": {
-            "version": "1.11.1",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/mocha/node_modules/readdirp": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 14.18.0"
             },
@@ -14233,8 +6362,9 @@
         },
         "node_modules/mocha/node_modules/supports-color": {
             "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -14247,29 +6377,34 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+            "dev": true
         },
         "node_modules/napi-build-utils": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
             "dev": true,
-            "license": "MIT",
             "optional": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true
         },
         "node_modules/node-abi": {
             "version": "3.75.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+            "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "semver": "^7.3.5"
@@ -14280,49 +6415,41 @@
         },
         "node_modules/node-addon-api": {
             "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+            "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
             "dev": true,
-            "license": "MIT",
             "optional": true
         },
         "node_modules/node-int64": {
             "version": "0.4.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+            "dev": true
         },
         "node_modules/node-releases": {
             "version": "2.0.19",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "dev": true
         },
         "node_modules/node-sarif-builder": {
-            "version": "2.0.3",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz",
+            "integrity": "sha512-kVIOdynrF2CRodHZeP/97Rh1syTUHBNiw17hUCIVhlhEsWlfJm19MuO56s4MdKbr22xWx6mzMnNAgXzVlIYM9Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@types/sarif": "^2.1.4",
-                "fs-extra": "^10.0.0"
+                "@types/sarif": "^2.1.7",
+                "fs-extra": "^11.1.1"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/node-sarif-builder/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/normalize-package-data": {
             "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^7.0.0",
                 "semver": "^7.3.5",
@@ -14334,8 +6461,9 @@
         },
         "node_modules/normalize-package-data/node_modules/hosted-git-info": {
             "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^10.0.1"
             },
@@ -14345,21 +6473,24 @@
         },
         "node_modules/normalize-package-data/node_modules/lru-cache": {
             "version": "10.4.3",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/normalize-url": {
-            "version": "8.0.1",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.2.tgz",
+            "integrity": "sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             },
@@ -14368,34 +6499,22 @@
             }
         },
         "node_modules/npm-run-path": {
-            "version": "5.3.0",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "path-key": "^4.0.0"
+                "path-key": "^3.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/nth-check": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0"
             },
@@ -14405,8 +6524,9 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -14416,16 +6536,18 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
             }
         },
         "node_modules/onetime": {
             "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -14437,14 +6559,15 @@
             }
         },
         "node_modules/open": {
-            "version": "10.1.2",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "default-browser": "^5.2.1",
                 "define-lazy-prop": "^3.0.0",
                 "is-inside-container": "^1.0.0",
-                "is-wsl": "^3.1.0"
+                "wsl-utils": "^0.1.0"
             },
             "engines": {
                 "node": ">=18"
@@ -14454,22 +6577,23 @@
             }
         },
         "node_modules/ora": {
-            "version": "7.0.1",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+            "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chalk": "^5.3.0",
-                "cli-cursor": "^4.0.0",
-                "cli-spinners": "^2.9.0",
+                "cli-cursor": "^5.0.0",
+                "cli-spinners": "^2.9.2",
                 "is-interactive": "^2.0.0",
-                "is-unicode-supported": "^1.3.0",
-                "log-symbols": "^5.1.0",
-                "stdin-discarder": "^0.1.0",
-                "string-width": "^6.1.0",
+                "is-unicode-supported": "^2.0.0",
+                "log-symbols": "^6.0.0",
+                "stdin-discarder": "^0.2.2",
+                "string-width": "^7.2.0",
                 "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -14477,8 +6601,9 @@
         },
         "node_modules/ora/node_modules/chalk": {
             "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -14488,28 +6613,43 @@
         },
         "node_modules/ora/node_modules/emoji-regex": {
             "version": "10.4.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+            "dev": true
         },
         "node_modules/ora/node_modules/is-unicode-supported": {
-            "version": "1.3.0",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ora/node_modules/log-symbols": {
-            "version": "5.1.0",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+            "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "chalk": "^5.0.0",
-                "is-unicode-supported": "^1.1.0"
+                "chalk": "^5.3.0",
+                "is-unicode-supported": "^1.3.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -14518,16 +6658,17 @@
             }
         },
         "node_modules/ora/node_modules/string-width": {
-            "version": "6.1.0",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^10.2.1",
-                "strip-ansi": "^7.0.1"
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -14535,16 +6676,18 @@
         },
         "node_modules/p-cancelable": {
             "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
+            "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             }
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -14557,8 +6700,9 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -14571,8 +6715,9 @@
         },
         "node_modules/p-map": {
             "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+            "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -14582,26 +6727,30 @@
         },
         "node_modules/p-try": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true
         },
         "node_modules/pako": {
             "version": "1.0.11",
-            "dev": true,
-            "license": "(MIT AND Zlib)"
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -14617,24 +6766,27 @@
         },
         "node_modules/parse-semver": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+            "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "semver": "^5.1.0"
             }
         },
         "node_modules/parse-semver/node_modules/semver": {
             "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
             }
         },
         "node_modules/parse5": {
             "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0"
             },
@@ -14644,8 +6796,9 @@
         },
         "node_modules/parse5-htmlparser2-tree-adapter": {
             "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+            "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "domhandler": "^5.0.3",
                 "parse5": "^7.0.0"
@@ -14656,8 +6809,9 @@
         },
         "node_modules/parse5-parser-stream": {
             "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+            "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "parse5": "^7.0.0"
             },
@@ -14667,8 +6821,9 @@
         },
         "node_modules/parse5/node_modules/entities": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -14678,60 +6833,64 @@
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
         },
         "node_modules/path-scurry": {
-            "version": "2.0.0",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": ">=16 || 14 >=14.18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.1.0",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "20 || >=22"
-            }
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true
         },
         "node_modules/path-type": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+            "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -14741,18 +6900,21 @@
         },
         "node_modules/pend": {
             "version": "1.2.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -14762,16 +6924,18 @@
         },
         "node_modules/pirates": {
             "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }
         },
         "node_modules/pkg-dir": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "find-up": "^4.0.0"
             },
@@ -14781,8 +6945,9 @@
         },
         "node_modules/pkg-dir/node_modules/find-up": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -14793,8 +6958,9 @@
         },
         "node_modules/pkg-dir/node_modules/locate-path": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -14804,8 +6970,9 @@
         },
         "node_modules/pkg-dir/node_modules/p-limit": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -14818,8 +6985,9 @@
         },
         "node_modules/pkg-dir/node_modules/p-locate": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -14829,16 +6997,27 @@
         },
         "node_modules/pluralize": {
             "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/prebuild-install": {
             "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "detect-libc": "^2.0.0",
@@ -14863,8 +7042,9 @@
         },
         "node_modules/pretty-format": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -14876,8 +7056,9 @@
         },
         "node_modules/pretty-format/node_modules/ansi-styles": {
             "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -14887,13 +7068,15 @@
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "node_modules/prompts": {
             "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "kleur": "^3.0.3",
                 "sisteransi": "^1.0.5"
@@ -14904,8 +7087,9 @@
         },
         "node_modules/pump": {
             "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -14914,14 +7098,17 @@
         },
         "node_modules/punycode.js": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/pure-rand": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+            "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
             "dev": true,
             "funding": [
                 {
@@ -14932,13 +7119,13 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fast-check"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/qs": {
             "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
             },
@@ -14951,6 +7138,8 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true,
             "funding": [
                 {
@@ -14965,13 +7154,13 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/quick-lru": {
             "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -14981,16 +7170,18 @@
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
         },
         "node_modules/rc": {
             "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
-            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
             "optional": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
@@ -15004,8 +7195,9 @@
         },
         "node_modules/rc-config-loader": {
             "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
+            "integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.4",
                 "js-yaml": "^4.1.0",
@@ -15013,10 +7205,29 @@
                 "require-from-string": "^2.0.2"
             }
         },
+        "node_modules/rc-config-loader/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "node_modules/rc-config-loader/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/rc/node_modules/strip-json-comments": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -15024,13 +7235,15 @@
         },
         "node_modules/react-is": {
             "version": "18.3.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true
         },
         "node_modules/read": {
             "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "mute-stream": "~0.0.4"
             },
@@ -15039,49 +7252,46 @@
             }
         },
         "node_modules/read-pkg": {
-            "version": "8.1.0",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+            "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@types/normalize-package-data": "^2.4.1",
+                "@types/normalize-package-data": "^2.4.3",
                 "normalize-package-data": "^6.0.0",
-                "parse-json": "^7.0.0",
-                "type-fest": "^4.2.0"
+                "parse-json": "^8.0.0",
+                "type-fest": "^4.6.0",
+                "unicorn-magic": "^0.1.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg/node_modules/json-parse-even-better-errors": {
-            "version": "3.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/read-pkg/node_modules/lines-and-columns": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
         "node_modules/read-pkg/node_modules/parse-json": {
-            "version": "7.1.1",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.21.4",
-                "error-ex": "^1.3.2",
-                "json-parse-even-better-errors": "^3.0.0",
-                "lines-and-columns": "^2.0.3",
-                "type-fest": "^3.8.0"
+                "@babel/code-frame": "^7.26.2",
+                "index-to-position": "^1.1.0",
+                "type-fest": "^4.39.1"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
             "engines": {
                 "node": ">=16"
             },
@@ -15089,12 +7299,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/read-pkg/node_modules/parse-json/node_modules/type-fest": {
-            "version": "3.13.1",
+        "node_modules/read-pkg/node_modules/unicorn-magic": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
             "dev": true,
-            "license": "(MIT OR CC0-1.0)",
             "engines": {
-                "node": ">=14.16"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -15102,8 +7313,9 @@
         },
         "node_modules/readable-stream": {
             "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -15116,8 +7328,9 @@
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -15127,23 +7340,26 @@
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/require-from-string": {
             "version": "2.0.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/resolve": {
             "version": "1.22.10",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.0",
                 "path-parse": "^1.0.7",
@@ -15161,13 +7377,15 @@
         },
         "node_modules/resolve-alpn": {
             "version": "1.2.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+            "dev": true
         },
         "node_modules/resolve-cwd": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "resolve-from": "^5.0.0"
             },
@@ -15175,26 +7393,29 @@
                 "node": ">=8"
             }
         },
-        "node_modules/resolve-cwd/node_modules/resolve-from": {
+        "node_modules/resolve-from": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/resolve.exports": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+            "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/responselike": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+            "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "lowercase-keys": "^3.0.0"
             },
@@ -15206,29 +7427,41 @@
             }
         },
         "node_modules/restore-cursor": {
-            "version": "4.0.0",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/restore-cursor/node_modules/signal-exit": {
-            "version": "3.0.7",
+        "node_modules/restore-cursor/node_modules/onetime": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "dev": true,
-            "license": "ISC"
+            "dependencies": {
+                "mimic-function": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/reusify": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -15236,8 +7469,10 @@
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -15248,10 +7483,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rimraf/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/rimraf/node_modules/glob": {
             "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -15267,10 +7514,23 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rimraf/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/run-applescript": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -15280,6 +7540,8 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
             "funding": [
                 {
@@ -15295,46 +7557,50 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+            "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
             "dev": true,
-            "license": "WTFPL OR ISC",
             "dependencies": {
                 "truncate-utf8-bytes": "^1.0.0"
             }
         },
         "node_modules/sax": {
             "version": "1.4.1",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+            "dev": true
         },
         "node_modules/secretlint": {
-            "version": "10.1.1",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.1.tgz",
+            "integrity": "sha512-3BghQkIGrDz3xJklX/COxgKbxHz2CAsGkXH4oh8MxeYVLlhA3L/TLhAxZiTyqeril+CnDGg8MUEZdX1dZNsxVA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@secretlint/config-creator": "^10.1.1",
-                "@secretlint/formatter": "^10.1.1",
-                "@secretlint/node": "^10.1.1",
-                "@secretlint/profiler": "^10.1.1",
+                "@secretlint/config-creator": "^10.2.1",
+                "@secretlint/formatter": "^10.2.1",
+                "@secretlint/node": "^10.2.1",
+                "@secretlint/profiler": "^10.2.1",
                 "debug": "^4.4.1",
                 "globby": "^14.1.0",
-                "read-pkg": "^8.1.0"
+                "read-pkg": "^9.0.1"
             },
             "bin": {
                 "secretlint": "bin/secretlint.js"
@@ -15345,6 +7611,8 @@
         },
         "node_modules/selenium-webdriver": {
             "version": "4.34.0",
+            "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.34.0.tgz",
+            "integrity": "sha512-zGfQFcsASAv3KrYzYh+iw4fFqB7iZAgHW7BU6rRz7isK1i1X4x3LvjmZad4bUUgHDwTnAhlqTzDh21byB+zHMg==",
             "dev": true,
             "funding": [
                 {
@@ -15356,7 +7624,6 @@
                     "url": "https://opencollective.com/selenium"
                 }
             ],
-            "license": "Apache-2.0",
             "dependencies": {
                 "@bazel/runfiles": "^6.3.1",
                 "jszip": "^3.10.1",
@@ -15368,9 +7635,10 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.1",
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
             "dev": true,
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -15380,21 +7648,41 @@
         },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
         },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/setimmediate": {
             "version": "1.0.5",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
         },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "kind-of": "^6.0.2"
             },
@@ -15404,8 +7692,9 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -15415,16 +7704,18 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3",
@@ -15441,8 +7732,9 @@
         },
         "node_modules/side-channel-list": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3"
@@ -15456,8 +7748,9 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -15473,8 +7766,9 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -15491,8 +7785,9 @@
         },
         "node_modules/signal-exit": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=14"
             },
@@ -15502,6 +7797,8 @@
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
             "dev": true,
             "funding": [
                 {
@@ -15517,11 +7814,12 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
             "optional": true
         },
         "node_modules/simple-get": {
             "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "dev": true,
             "funding": [
                 {
@@ -15537,7 +7835,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "decompress-response": "^6.0.0",
@@ -15547,21 +7844,24 @@
         },
         "node_modules/sisteransi": {
             "version": "1.0.5",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true
         },
         "node_modules/slash": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/slice-ansi": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -15576,16 +7876,18 @@
         },
         "node_modules/source-map": {
             "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/source-map-support": {
             "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -15593,8 +7895,9 @@
         },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -15602,13 +7905,15 @@
         },
         "node_modules/spdx-exceptions": {
             "version": "2.5.0",
-            "dev": true,
-            "license": "CC-BY-3.0"
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "dev": true
         },
         "node_modules/spdx-expression-parse": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -15616,18 +7921,21 @@
         },
         "node_modules/spdx-license-ids": {
             "version": "3.0.21",
-            "dev": true,
-            "license": "CC0-1.0"
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+            "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+            "dev": true
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
-            "dev": true,
-            "license": "BSD-3-Clause"
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "escape-string-regexp": "^2.0.0"
             },
@@ -15637,21 +7945,20 @@
         },
         "node_modules/stack-utils/node_modules/escape-string-regexp": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/stdin-discarder": {
-            "version": "0.1.0",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+            "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bl": "^5.0.0"
-            },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -15659,16 +7966,18 @@
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
         },
         "node_modules/string-length": {
             "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+            "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "char-regex": "^1.0.2",
                 "strip-ansi": "^6.0.0"
@@ -15679,16 +7988,18 @@
         },
         "node_modules/string-length/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/string-length/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -15698,8 +8009,9 @@
         },
         "node_modules/string-width": {
             "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^9.2.2",
@@ -15715,8 +8027,9 @@
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -15728,21 +8041,24 @@
         },
         "node_modules/string-width-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/string-width-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -15752,8 +8068,9 @@
         },
         "node_modules/strip-ansi": {
             "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -15767,8 +8084,9 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -15778,35 +8096,36 @@
         },
         "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/strip-bom": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/strip-final-newline": {
-            "version": "3.0.0",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=6"
             }
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -15816,16 +8135,46 @@
         },
         "node_modules/structured-source": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+            "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "boundary": "^2.0.0"
             }
         },
         "node_modules/supports-color": {
-            "version": "7.2.0",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+            "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
             "dev": true,
-            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/supports-hyperlinks": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+            "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+            }
+        },
+        "node_modules/supports-hyperlinks/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -15833,22 +8182,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/supports-hyperlinks": {
-            "version": "2.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0",
-                "supports-color": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -15858,8 +8196,9 @@
         },
         "node_modules/system-architecture": {
             "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
+            "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -15869,8 +8208,9 @@
         },
         "node_modules/table": {
             "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+            "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",
@@ -15884,21 +8224,24 @@
         },
         "node_modules/table/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/table/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/table/node_modules/string-width": {
             "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -15910,8 +8253,9 @@
         },
         "node_modules/table/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -15920,17 +8264,19 @@
             }
         },
         "node_modules/tapable": {
-            "version": "2.2.1",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+            "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/tar-fs": {
             "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+            "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "chownr": "^1.1.1",
@@ -15941,8 +8287,9 @@
         },
         "node_modules/tar-stream": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "bl": "^4.0.3",
@@ -15955,45 +8302,11 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tar-stream/node_modules/bl": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/tar-stream/node_modules/buffer": {
-            "version": "5.7.1",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
         "node_modules/tar-stream/node_modules/readable-stream": {
             "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -16006,16 +8319,18 @@
         },
         "node_modules/targz": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/targz/-/targz-1.0.1.tgz",
+            "integrity": "sha512-6q4tP9U55mZnRuMTBqnqc3nwYQY3kv+QthCFZuMk+Tn1qYUnMPmL/JZ/mzgXINzFpSqfU+242IFmFU9VPvqaQw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "tar-fs": "^1.8.1"
             }
         },
         "node_modules/targz/node_modules/bl": {
             "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+            "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
@@ -16023,8 +8338,9 @@
         },
         "node_modules/targz/node_modules/pump": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+            "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -16032,8 +8348,9 @@
         },
         "node_modules/targz/node_modules/tar-fs": {
             "version": "1.16.5",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.5.tgz",
+            "integrity": "sha512-1ergVCCysmwHQNrOS+Pjm4DQ4nrGp43+Xnu4MRGjCnQu/m3hEgLNS78d5z+B8OJ1hN5EejJdCSFZE1oM6AQXAQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chownr": "^1.0.1",
                 "mkdirp": "^0.5.1",
@@ -16043,8 +8360,9 @@
         },
         "node_modules/targz/node_modules/tar-stream": {
             "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+            "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "bl": "^1.0.0",
                 "buffer-alloc": "^1.2.0",
@@ -16059,15 +8377,31 @@
             }
         },
         "node_modules/terminal-link": {
-            "version": "2.1.1",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+            "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "ansi-escapes": "^4.2.1",
-                "supports-hyperlinks": "^2.0.0"
+                "ansi-escapes": "^7.0.0",
+                "supports-hyperlinks": "^3.2.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/terminal-link/node_modules/ansi-escapes": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+            "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+            "dev": true,
+            "dependencies": {
+                "environment": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -16075,8 +8409,9 @@
         },
         "node_modules/test-exclude": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^7.1.4",
@@ -16086,10 +8421,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/test-exclude/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/test-exclude/node_modules/glob": {
             "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -16105,15 +8452,29 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/test-exclude/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "dev": true
         },
         "node_modules/textextensions": {
             "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+            "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
             "dev": true,
-            "license": "Artistic-2.0",
             "dependencies": {
                 "editions": "^6.21.0"
             },
@@ -16126,26 +8487,64 @@
         },
         "node_modules/tmp": {
             "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.14"
             }
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
-            "dev": true,
-            "license": "BSD-3-Clause"
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+            "dev": true
         },
         "node_modules/to-buffer": {
-            "version": "1.1.1",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+            "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
             "dev": true,
-            "license": "MIT"
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/to-buffer/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true
+        },
+        "node_modules/to-buffer/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -16155,34 +8554,42 @@
         },
         "node_modules/traverse": {
             "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
             "dev": true,
-            "license": "MIT/X11"
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/truncate-utf8-bytes": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+            "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
             "dev": true,
-            "license": "WTFPL",
             "dependencies": {
                 "utf8-byte-length": "^1.0.1"
             }
         },
         "node_modules/tslib": {
             "version": "2.8.1",
-            "dev": true,
-            "license": "0BSD"
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
             }
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "dev": true,
-            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
@@ -16193,27 +8600,44 @@
         },
         "node_modules/type-detect": {
             "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/type-fest": {
-            "version": "4.41.0",
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true,
-            "license": "(MIT OR CC0-1.0)",
             "engines": {
-                "node": ">=16"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "dev": true,
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/typed-rest-client": {
             "version": "1.8.11",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+            "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "qs": "^6.9.1",
                 "tunnel": "0.0.6",
@@ -16222,8 +8646,9 @@
         },
         "node_modules/typescript": {
             "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -16235,31 +8660,36 @@
         },
         "node_modules/uc.micro": {
             "version": "2.1.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "dev": true
         },
         "node_modules/underscore": {
             "version": "1.13.7",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+            "dev": true
         },
         "node_modules/undici": {
-            "version": "7.11.0",
+            "version": "7.12.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.12.0.tgz",
+            "integrity": "sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
-            "version": "6.21.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+            "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+            "dev": true
         },
         "node_modules/unicorn-magic": {
-            "version": "0.1.0",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -16269,31 +8699,30 @@
         },
         "node_modules/universalify": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
             }
         },
         "node_modules/unzipper": {
-            "version": "0.10.14",
+            "version": "0.12.3",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+            "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "big-integer": "^1.6.17",
-                "binary": "~0.3.0",
-                "bluebird": "~3.4.1",
-                "buffer-indexof-polyfill": "~1.0.0",
+                "bluebird": "~3.7.2",
                 "duplexer2": "~0.1.4",
-                "fstream": "^1.0.12",
+                "fs-extra": "^11.2.0",
                 "graceful-fs": "^4.2.2",
-                "listenercount": "~1.0.1",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "~1.0.4"
+                "node-int64": "^0.4.0"
             }
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
             "dev": true,
             "funding": [
                 {
@@ -16309,7 +8738,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -16323,31 +8751,36 @@
         },
         "node_modules/url-join": {
             "version": "4.0.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+            "dev": true
         },
         "node_modules/utf8-byte-length": {
             "version": "1.0.5",
-            "dev": true,
-            "license": "(WTFPL OR MIT)"
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+            "dev": true
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
         },
         "node_modules/uuid": {
             "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+            "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -16359,8 +8792,9 @@
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -16368,8 +8802,9 @@
         },
         "node_modules/version-range": {
             "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.14.0.tgz",
+            "integrity": "sha512-gjb0ARm9qlcBAonU4zPwkl9ecKkas+tC2CGwFfptTCWWIVTWY1YUbT2zZKsOAF1jR/tNxxyLwwG0cb42XlYcTg==",
             "dev": true,
-            "license": "Artistic-2.0",
             "engines": {
                 "node": ">=4"
             },
@@ -16378,25 +8813,26 @@
             }
         },
         "node_modules/vscode-extension-tester": {
-            "version": "8.15.0",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-8.17.0.tgz",
+            "integrity": "sha512-B97Aas11bEcM0dcXCn/D+hg58Xwugf0nSu464gvfq5uXYUCUVWNPM7r971DwXxuWd+mcREcuW6/bz07Mod6zBA==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
-                "@redhat-developer/locators": "^1.13.0",
-                "@redhat-developer/page-objects": "^1.13.0",
+                "@redhat-developer/locators": "^1.15.0",
+                "@redhat-developer/page-objects": "^1.15.0",
                 "@types/selenium-webdriver": "^4.1.28",
-                "@vscode/vsce": "^3.5.0",
+                "@vscode/vsce": "^3.6.0",
                 "c8": "^10.1.3",
                 "commander": "^14.0.0",
                 "compare-versions": "^6.1.1",
                 "find-up": "7.0.0",
                 "fs-extra": "^11.3.0",
-                "glob": "^11.0.2",
+                "glob": "^11.0.3",
                 "got": "^14.4.7",
                 "hpagent": "^1.2.0",
                 "js-yaml": "^4.1.0",
                 "sanitize-filename": "^1.6.3",
-                "selenium-webdriver": "^4.33.0",
+                "selenium-webdriver": "^4.34.0",
                 "targz": "^1.0.1",
                 "unzipper": "^0.12.3"
             },
@@ -16410,30 +8846,24 @@
         },
         "node_modules/vscode-extension-tester/node_modules/@bcoe/v8-coverage": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/vscode-extension-tester/node_modules/bluebird": {
-            "version": "3.7.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/vscode-extension-tester/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
+        "node_modules/vscode-extension-tester/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
         },
         "node_modules/vscode-extension-tester/node_modules/c8": {
             "version": "10.1.3",
+            "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
+            "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.1",
                 "@istanbuljs/schema": "^0.1.3",
@@ -16464,8 +8894,9 @@
         },
         "node_modules/vscode-extension-tester/node_modules/c8/node_modules/find-up": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -16479,8 +8910,9 @@
         },
         "node_modules/vscode-extension-tester/node_modules/find-up": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+            "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "locate-path": "^7.2.0",
                 "path-exists": "^5.0.0",
@@ -16495,8 +8927,9 @@
         },
         "node_modules/vscode-extension-tester/node_modules/find-up/node_modules/locate-path": {
             "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+            "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-locate": "^6.0.0"
             },
@@ -16509,49 +8942,92 @@
         },
         "node_modules/vscode-extension-tester/node_modules/find-up/node_modules/path-exists": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+            "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
-        "node_modules/vscode-extension-tester/node_modules/jackspeak": {
-            "version": "3.4.3",
+        "node_modules/vscode-extension-tester/node_modules/glob": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+            "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "foreground-child": "^3.3.1",
+                "jackspeak": "^4.1.1",
+                "minimatch": "^10.0.3",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/vscode-extension-tester/node_modules/glob/node_modules/minimatch": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+            "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+            "dev": true,
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/vscode-extension-tester/node_modules/jackspeak": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+            "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+            "dev": true,
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
+            "engines": {
+                "node": "20 || >=22"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/vscode-extension-tester/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
             },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/vscode-extension-tester/node_modules/lru-cache": {
-            "version": "10.4.3",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+            "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
             "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/vscode-extension-tester/node_modules/minimatch": {
-            "version": "9.0.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": "20 || >=22"
             }
         },
         "node_modules/vscode-extension-tester/node_modules/p-limit": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^1.0.0"
             },
@@ -16564,8 +9040,9 @@
         },
         "node_modules/vscode-extension-tester/node_modules/p-locate": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+            "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-limit": "^4.0.0"
             },
@@ -16577,15 +9054,16 @@
             }
         },
         "node_modules/vscode-extension-tester/node_modules/path-scurry": {
-            "version": "1.11.1",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
             "dev": true,
-            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.18"
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -16593,8 +9071,9 @@
         },
         "node_modules/vscode-extension-tester/node_modules/test-exclude": {
             "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+            "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^10.4.1",
@@ -16606,8 +9085,9 @@
         },
         "node_modules/vscode-extension-tester/node_modules/test-exclude/node_modules/glob": {
             "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -16623,22 +9103,60 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/vscode-extension-tester/node_modules/unzipper": {
-            "version": "0.12.3",
+        "node_modules/vscode-extension-tester/node_modules/test-exclude/node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "bluebird": "~3.7.2",
-                "duplexer2": "~0.1.4",
-                "fs-extra": "^11.2.0",
-                "graceful-fs": "^4.2.2",
-                "node-int64": "^0.4.0"
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/vscode-extension-tester/node_modules/test-exclude/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true
+        },
+        "node_modules/vscode-extension-tester/node_modules/test-exclude/node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/vscode-extension-tester/node_modules/unicorn-magic": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/vscode-extension-tester/node_modules/yocto-queue": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+            "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12.20"
             },
@@ -16648,8 +9166,10 @@
         },
         "node_modules/vscode-test": {
             "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
+            "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+            "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
                 "https-proxy-agent": "^5.0.0",
@@ -16660,18 +9180,83 @@
                 "node": ">=8.9.3"
             }
         },
+        "node_modules/vscode-test/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/vscode-test/node_modules/bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
+        },
+        "node_modules/vscode-test/node_modules/http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/vscode-test/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/vscode-test/node_modules/unzipper": {
+            "version": "0.10.14",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+            "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+            "dev": true,
+            "dependencies": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "^1.0.12",
+                "graceful-fs": "^4.2.2",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "~1.0.4"
+            }
+        },
         "node_modules/walker": {
             "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+            "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "makeerror": "1.0.12"
             }
         },
         "node_modules/whatwg-encoding": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -16681,15 +9266,17 @@
         },
         "node_modules/whatwg-mimetype": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/which": {
             "version": "5.0.0",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
             "dependencies": {
                 "isexe": "^3.1.1"
             },
@@ -16700,15 +9287,38 @@
                 "node": "^18.17.0 || >=20.5.0"
             }
         },
-        "node_modules/workerpool": {
-            "version": "6.5.1",
+        "node_modules/which-typed-array": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
             "dev": true,
-            "license": "Apache-2.0"
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/workerpool": {
+            "version": "9.3.3",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.3.tgz",
+            "integrity": "sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==",
+            "dev": true
         },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^6.1.0",
                 "string-width": "^5.0.1",
@@ -16724,8 +9334,9 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -16740,21 +9351,24 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -16766,8 +9380,9 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -16777,8 +9392,9 @@
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {
             "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -16788,13 +9404,15 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
         },
         "node_modules/write-file-atomic": {
             "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+            "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^3.0.7"
@@ -16805,13 +9423,15 @@
         },
         "node_modules/write-file-atomic/node_modules/signal-exit": {
             "version": "3.0.7",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true
         },
         "node_modules/ws": {
             "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -16828,10 +9448,26 @@
                 }
             }
         },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dev": true,
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/xml2js": {
             "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -16842,37 +9478,42 @@
         },
         "node_modules/xmlbuilder": {
             "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             }
         },
         "node_modules/xtend": {
             "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.4"
             }
         },
         "node_modules/y18n": {
             "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/yallist": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "ISC"
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true
         },
         "node_modules/yargs": {
             "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -16888,16 +9529,18 @@
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/yargs-unparser": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.0.0",
                 "decamelize": "^4.0.0",
@@ -16908,23 +9551,38 @@
                 "node": ">=10"
             }
         },
+        "node_modules/yargs-unparser/node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/yargs/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/yargs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/yargs/node_modules/string-width": {
             "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -16936,8 +9594,9 @@
         },
         "node_modules/yargs/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -16947,8 +9606,9 @@
         },
         "node_modules/yauzl": {
             "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
@@ -16956,16 +9616,18 @@
         },
         "node_modules/yazl": {
             "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3"
             }
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "answer-set-programming-language-support",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "answer-set-programming-language-support",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dependencies": {
                 "@vscode/codicons": "0.0.36",
                 "ajv": "^8.17.1",
-                "clingo-wasm": "file:../clingo-wasm",
+                "clingo-wasm": "^0.3.2",
                 "which": "^5.0.0"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,11 +50,8558 @@
                 "worker-loader": "^3.0.8"
             }
         },
+        "../clingo-wasm/node_modules/@ampproject/remapping": {
+            "version": "2.3.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/code-frame": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/compat-data": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/core": {
+            "version": "7.26.10",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ampproject/remapping": "^2.2.0",
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.26.10",
+                "@babel/helper-compilation-targets": "^7.26.5",
+                "@babel/helper-module-transforms": "^7.26.0",
+                "@babel/helpers": "^7.26.10",
+                "@babel/parser": "^7.26.10",
+                "@babel/template": "^7.26.9",
+                "@babel/traverse": "^7.26.10",
+                "@babel/types": "^7.26.10",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/generator": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.27.1",
+                "@babel/types": "^7.27.1",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-annotate-as-pure": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-compilation-targets": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.27.1",
+                "@babel/helper-validator-option": "^7.27.1",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-create-class-features-plugin": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.1",
+                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/traverse": "^7.27.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-create-regexp-features-plugin": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.1",
+                "regexpu-core": "^6.2.0",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-define-polyfill-provider": {
+            "version": "0.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-compilation-targets": "^7.22.6",
+                "@babel/helper-plugin-utils": "^7.22.5",
+                "debug": "^4.1.1",
+                "lodash.debounce": "^4.0.8",
+                "resolve": "^1.14.2"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-member-expression-to-functions": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-module-imports": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-module-transforms": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-optimise-call-expression": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-plugin-utils": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-remap-async-to-generator": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.1",
+                "@babel/helper-wrap-function": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-replace-supers": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-validator-identifier": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-validator-option": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helper-wrap-function": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.27.1",
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/helpers": {
+            "version": "7.26.10",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.26.9",
+                "@babel/types": "^7.26.10"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/parser": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.27.1"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/plugin-transform-optional-chaining": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.13.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-proposal-private-property-in-object": {
+            "version": "7.21.0-placeholder-for-preset-env.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-bigint": {
+            "version": "7.8.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-class-properties": {
+            "version": "7.12.13",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-class-static-block": {
+            "version": "7.14.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-import-assertions": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-import-attributes": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-import-meta": {
+            "version": "7.10.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-jsx": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.8.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-private-property-in-object": {
+            "version": "7.14.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-top-level-await": {
+            "version": "7.14.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-typescript": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+            "version": "7.18.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+                "@babel/helper-plugin-utils": "^7.18.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-arrow-functions": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-async-generator-functions": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-remap-async-to-generator": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-async-to-generator": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-remap-async-to-generator": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-block-scoping": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-class-properties": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-class-static-block": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.12.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-classes": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.1",
+                "@babel/helper-compilation-targets": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.27.1",
+                "@babel/traverse": "^7.27.1",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-computed-properties": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/template": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-destructuring": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-dotall-regex": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-duplicate-keys": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-dynamic-import": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-export-namespace-from": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-for-of": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-function-name": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-compilation-targets": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-json-strings": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-literals": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-member-expression-literals": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-modules-amd": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-modules-commonjs": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-modules-systemjs": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-modules-umd": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-new-target": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-numeric-separator": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-object-rest-spread": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-compilation-targets": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/plugin-transform-parameters": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-object-super": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-optional-catch-binding": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-optional-chaining": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-parameters": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-private-methods": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-private-property-in-object": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.1",
+                "@babel/helper-create-class-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-property-literals": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-regenerator": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-regexp-modifiers": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-reserved-words": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-shorthand-properties": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-spread": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-sticky-regex": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-template-literals": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-typeof-symbol": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-typescript": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.1",
+                "@babel/helper-create-class-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/plugin-syntax-typescript": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-unicode-escapes": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-unicode-property-regex": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-unicode-regex": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/preset-env": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.27.1",
+                "@babel/helper-compilation-targets": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
+                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+                "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+                "@babel/plugin-syntax-import-assertions": "^7.27.1",
+                "@babel/plugin-syntax-import-attributes": "^7.27.1",
+                "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+                "@babel/plugin-transform-arrow-functions": "^7.27.1",
+                "@babel/plugin-transform-async-generator-functions": "^7.27.1",
+                "@babel/plugin-transform-async-to-generator": "^7.27.1",
+                "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+                "@babel/plugin-transform-block-scoping": "^7.27.1",
+                "@babel/plugin-transform-class-properties": "^7.27.1",
+                "@babel/plugin-transform-class-static-block": "^7.27.1",
+                "@babel/plugin-transform-classes": "^7.27.1",
+                "@babel/plugin-transform-computed-properties": "^7.27.1",
+                "@babel/plugin-transform-destructuring": "^7.27.1",
+                "@babel/plugin-transform-dotall-regex": "^7.27.1",
+                "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+                "@babel/plugin-transform-dynamic-import": "^7.27.1",
+                "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
+                "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+                "@babel/plugin-transform-for-of": "^7.27.1",
+                "@babel/plugin-transform-function-name": "^7.27.1",
+                "@babel/plugin-transform-json-strings": "^7.27.1",
+                "@babel/plugin-transform-literals": "^7.27.1",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
+                "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+                "@babel/plugin-transform-modules-amd": "^7.27.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+                "@babel/plugin-transform-modules-systemjs": "^7.27.1",
+                "@babel/plugin-transform-modules-umd": "^7.27.1",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+                "@babel/plugin-transform-new-target": "^7.27.1",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
+                "@babel/plugin-transform-numeric-separator": "^7.27.1",
+                "@babel/plugin-transform-object-rest-spread": "^7.27.1",
+                "@babel/plugin-transform-object-super": "^7.27.1",
+                "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
+                "@babel/plugin-transform-optional-chaining": "^7.27.1",
+                "@babel/plugin-transform-parameters": "^7.27.1",
+                "@babel/plugin-transform-private-methods": "^7.27.1",
+                "@babel/plugin-transform-private-property-in-object": "^7.27.1",
+                "@babel/plugin-transform-property-literals": "^7.27.1",
+                "@babel/plugin-transform-regenerator": "^7.27.1",
+                "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+                "@babel/plugin-transform-reserved-words": "^7.27.1",
+                "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+                "@babel/plugin-transform-spread": "^7.27.1",
+                "@babel/plugin-transform-sticky-regex": "^7.27.1",
+                "@babel/plugin-transform-template-literals": "^7.27.1",
+                "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+                "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+                "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+                "@babel/plugin-transform-unicode-regex": "^7.27.1",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
+                "@babel/preset-modules": "0.1.6-no-external-plugins",
+                "babel-plugin-polyfill-corejs2": "^0.4.10",
+                "babel-plugin-polyfill-corejs3": "^0.11.0",
+                "babel-plugin-polyfill-regenerator": "^0.6.1",
+                "core-js-compat": "^3.40.0",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/preset-modules": {
+            "version": "0.1.6-no-external-plugins",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/preset-typescript": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+                "@babel/plugin-transform-typescript": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/template": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.1",
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/traverse": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.27.1",
+                "@babel/parser": "^7.27.1",
+                "@babel/template": "^7.27.1",
+                "@babel/types": "^7.27.1",
+                "debug": "^4.3.1",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@babel/types": {
+            "version": "7.27.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@discoveryjs/json-ext": {
+            "version": "0.6.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.17.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "../clingo-wasm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/@istanbuljs/load-nyc-config": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/@istanbuljs/schema": {
+            "version": "0.1.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/console": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/core": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/console": "^29.7.0",
+                "@jest/reporters": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.2.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.9",
+                "jest-changed-files": "^29.7.0",
+                "jest-config": "^29.7.0",
+                "jest-haste-map": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-resolve-dependencies": "^29.7.0",
+                "jest-runner": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "jest-watcher": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "pretty-format": "^29.7.0",
+                "slash": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/environment": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "jest-mock": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/expect": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expect": "^29.7.0",
+                "jest-snapshot": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/expect-utils": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jest-get-type": "^29.6.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/fake-timers": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@sinonjs/fake-timers": "^10.0.2",
+                "@types/node": "*",
+                "jest-message-util": "^29.7.0",
+                "jest-mock": "^29.7.0",
+                "jest-util": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/globals": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/expect": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "jest-mock": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/reporters": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^6.0.0",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.1.3",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-worker": "^29.7.0",
+                "slash": "^3.0.0",
+                "string-length": "^4.0.1",
+                "strip-ansi": "^6.0.0",
+                "v8-to-istanbul": "^9.0.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/schemas": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.27.8"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/source-map": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.2.9"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/test-result": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/console": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/test-sequencer": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/test-result": "^29.7.0",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/transform": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.11.6",
+                "@jest/types": "^29.6.3",
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "babel-plugin-istanbul": "^6.1.1",
+                "chalk": "^4.0.0",
+                "convert-source-map": "^2.0.0",
+                "fast-json-stable-stringify": "^2.1.0",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-util": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "pirates": "^4.0.4",
+                "slash": "^3.0.0",
+                "write-file-atomic": "^4.0.2"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jest/types": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "^29.6.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/set-array": "^1.2.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jridgewell/set-array": {
+            "version": "1.2.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@jridgewell/source-map": {
+            "version": "0.3.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
+            }
+        },
+        "../clingo-wasm/node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "../clingo-wasm/node_modules/@jsonjoy.com/base64": {
+            "version": "1.1.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "../clingo-wasm/node_modules/@jsonjoy.com/json-pack": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "^1.1.1",
+                "@jsonjoy.com/util": "^1.1.2",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^1.20.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "../clingo-wasm/node_modules/@jsonjoy.com/util": {
+            "version": "1.5.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "../clingo-wasm/node_modules/@leichtgewicht/ip-codec": {
+            "version": "2.0.5",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "../clingo-wasm/node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "../clingo-wasm/node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "../clingo-wasm/node_modules/@sinclair/typebox": {
+            "version": "0.27.8",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@sinonjs/commons": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/@sinonjs/fake-timers": {
+            "version": "10.3.0",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/babel__core": {
+            "version": "7.20.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/babel__generator": {
+            "version": "7.6.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/babel__template": {
+            "version": "7.4.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/babel__traverse": {
+            "version": "7.20.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.20.7"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/body-parser": {
+            "version": "1.19.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/bonjour": {
+            "version": "3.5.13",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/connect": {
+            "version": "3.4.38",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/connect-history-api-fallback": {
+            "version": "1.5.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/express-serve-static-core": "*",
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/emscripten": {
+            "version": "1.40.1",
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/eslint": {
+            "version": "9.6.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/eslint-scope": {
+            "version": "3.7.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/estree": {
+            "version": "1.0.6",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/express": {
+            "version": "4.17.21",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^4.17.33",
+                "@types/qs": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/express-serve-static-core": {
+            "version": "5.0.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/express/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/graceful-fs": {
+            "version": "4.1.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/http-errors": {
+            "version": "2.0.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/http-proxy": {
+            "version": "1.17.16",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/istanbul-lib-coverage": {
+            "version": "2.0.6",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/istanbul-lib-report": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/istanbul-lib-coverage": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/istanbul-reports": {
+            "version": "3.0.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/istanbul-lib-report": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/jest": {
+            "version": "29.5.14",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expect": "^29.0.0",
+                "pretty-format": "^29.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/mime": {
+            "version": "1.3.5",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/node": {
+            "version": "22.15.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/node-forge": {
+            "version": "1.3.11",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/qs": {
+            "version": "6.9.18",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/range-parser": {
+            "version": "1.2.7",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/retry": {
+            "version": "0.12.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/send": {
+            "version": "0.17.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/serve-index": {
+            "version": "1.9.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/express": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/serve-static": {
+            "version": "1.15.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*",
+                "@types/send": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/sockjs": {
+            "version": "0.3.36",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/stack-utils": {
+            "version": "2.0.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@types/ws": {
+            "version": "8.18.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/yargs": {
+            "version": "17.0.33",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/@types/yargs-parser": {
+            "version": "21.0.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/ast": {
+            "version": "1.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/helper-numbers": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+            }
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.13.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/helper-api-error": {
+            "version": "1.13.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/helper-buffer": {
+            "version": "1.14.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/helper-numbers": {
+            "version": "1.13.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.13.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/helper-wasm-section": {
+            "version": "1.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/wasm-gen": "1.14.1"
+            }
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/ieee754": {
+            "version": "1.13.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/leb128": {
+            "version": "1.13.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/utf8": {
+            "version": "1.13.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/wasm-edit": {
+            "version": "1.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/helper-wasm-section": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-opt": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1",
+                "@webassemblyjs/wast-printer": "1.14.1"
+            }
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/wasm-gen": {
+            "version": "1.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
+            }
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/wasm-opt": {
+            "version": "1.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1"
+            }
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/wasm-parser": {
+            "version": "1.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
+            }
+        },
+        "../clingo-wasm/node_modules/@webassemblyjs/wast-printer": {
+            "version": "1.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "../clingo-wasm/node_modules/@webpack-cli/configtest": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "peerDependencies": {
+                "webpack": "^5.82.0",
+                "webpack-cli": "6.x.x"
+            }
+        },
+        "../clingo-wasm/node_modules/@webpack-cli/info": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "peerDependencies": {
+                "webpack": "^5.82.0",
+                "webpack-cli": "6.x.x"
+            }
+        },
+        "../clingo-wasm/node_modules/@webpack-cli/serve": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "peerDependencies": {
+                "webpack": "^5.82.0",
+                "webpack-cli": "6.x.x"
+            },
+            "peerDependenciesMeta": {
+                "webpack-dev-server": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/@xtuc/ieee754": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "../clingo-wasm/node_modules/@xtuc/long": {
+            "version": "4.2.2",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "../clingo-wasm/node_modules/@zeit/schemas": {
+            "version": "2.36.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/accepts": {
+            "version": "1.3.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/acorn": {
+            "version": "8.14.1",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "../clingo-wasm/node_modules/ajv": {
+            "version": "6.12.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "../clingo-wasm/node_modules/ajv-formats": {
+            "version": "2.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.17.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "../clingo-wasm/node_modules/ajv-formats/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^6.9.1"
+            }
+        },
+        "../clingo-wasm/node_modules/ansi-align": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.1.0"
+            }
+        },
+        "../clingo-wasm/node_modules/ansi-align/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/ansi-align/node_modules/string-width": {
+            "version": "4.2.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/ansi-html-community": {
+            "version": "0.0.8",
+            "dev": true,
+            "engines": [
+                "node >= 0.8.0"
+            ],
+            "license": "Apache-2.0",
+            "bin": {
+                "ansi-html": "bin/ansi-html"
+            }
+        },
+        "../clingo-wasm/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/anymatch": {
+            "version": "3.1.3",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "../clingo-wasm/node_modules/arch": {
+            "version": "2.2.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/arg": {
+            "version": "5.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/argparse": {
+            "version": "1.0.10",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "../clingo-wasm/node_modules/array-flatten": {
+            "version": "1.1.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/array-union": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/async": {
+            "version": "3.2.6",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/babel-jest": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/transform": "^29.7.0",
+                "@types/babel__core": "^7.1.14",
+                "babel-plugin-istanbul": "^6.1.1",
+                "babel-preset-jest": "^29.6.3",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.9",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/babel-plugin-istanbul": {
+            "version": "6.1.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-instrument": "^5.0.4",
+                "test-exclude": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+            "version": "5.2.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@babel/core": "^7.12.3",
+                "@babel/parser": "^7.14.7",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.2.0",
+                "semver": "^6.3.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/babel-plugin-jest-hoist": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.3.3",
+                "@babel/types": "^7.3.3",
+                "@types/babel__core": "^7.1.14",
+                "@types/babel__traverse": "^7.0.6"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/babel-plugin-polyfill-corejs2": {
+            "version": "0.4.12",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.22.6",
+                "@babel/helper-define-polyfill-provider": "^0.6.3",
+                "semver": "^6.3.1"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/babel-plugin-polyfill-corejs3": {
+            "version": "0.11.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-define-polyfill-provider": "^0.6.3",
+                "core-js-compat": "^3.40.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/babel-plugin-polyfill-regenerator": {
+            "version": "0.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-define-polyfill-provider": "^0.6.3"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/babel-preset-current-node-syntax": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.12.13",
+                "@babel/plugin-syntax-class-static-block": "^7.14.5",
+                "@babel/plugin-syntax-import-attributes": "^7.24.7",
+                "@babel/plugin-syntax-import-meta": "^7.10.4",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+                "@babel/plugin-syntax-top-level-await": "^7.14.5"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/babel-preset-jest": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "babel-plugin-jest-hoist": "^29.6.3",
+                "babel-preset-current-node-syntax": "^1.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/batch": {
+            "version": "0.6.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/big.js": {
+            "version": "5.2.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/body-parser": {
+            "version": "1.20.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "content-type": "~1.0.5",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "on-finished": "2.4.1",
+                "qs": "6.13.0",
+                "raw-body": "2.5.2",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "../clingo-wasm/node_modules/body-parser/node_modules/bytes": {
+            "version": "3.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/body-parser/node_modules/debug": {
+            "version": "2.6.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/body-parser/node_modules/ms": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/bonjour-service": {
+            "version": "1.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "multicast-dns": "^7.2.5"
+            }
+        },
+        "../clingo-wasm/node_modules/boxen": {
+            "version": "7.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-align": "^3.0.1",
+                "camelcase": "^7.0.0",
+                "chalk": "^5.0.1",
+                "cli-boxes": "^3.0.0",
+                "string-width": "^5.1.2",
+                "type-fest": "^2.13.0",
+                "widest-line": "^4.0.1",
+                "wrap-ansi": "^8.0.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/boxen/node_modules/camelcase": {
+            "version": "7.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/boxen/node_modules/chalk": {
+            "version": "5.4.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/boxen/node_modules/type-fest": {
+            "version": "2.19.0",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "../clingo-wasm/node_modules/braces": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/browserslist": {
+            "version": "4.24.4",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "caniuse-lite": "^1.0.30001688",
+                "electron-to-chromium": "^1.5.73",
+                "node-releases": "^2.0.19",
+                "update-browserslist-db": "^1.1.1"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "../clingo-wasm/node_modules/bser": {
+            "version": "2.1.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-int64": "^0.4.0"
+            }
+        },
+        "../clingo-wasm/node_modules/buffer-from": {
+            "version": "1.1.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/bundle-name": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/bytes": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "../clingo-wasm/node_modules/call-bound": {
+            "version": "1.0.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/callsites": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/camelcase": {
+            "version": "5.3.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/caniuse-lite": {
+            "version": "1.0.30001704",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "../clingo-wasm/node_modules/chalk": {
+            "version": "4.1.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/chalk-template": {
+            "version": "0.4.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk-template?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/char-regex": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/chokidar": {
+            "version": "3.6.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "../clingo-wasm/node_modules/chrome-trace-event": {
+            "version": "1.0.4",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
+        "../clingo-wasm/node_modules/ci-info": {
+            "version": "3.9.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/cjs-module-lexer": {
+            "version": "1.4.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/cli-boxes": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/clipboardy": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "arch": "^2.2.0",
+                "execa": "^5.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/cliui": {
+            "version": "8.0.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "../clingo-wasm/node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/clone-deep": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/co": {
+            "version": "4.6.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
+        "../clingo-wasm/node_modules/collect-v8-coverage": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/color-convert": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/color-name": {
+            "version": "1.1.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/colorette": {
+            "version": "2.0.20",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/commander": {
+            "version": "13.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "../clingo-wasm/node_modules/commondir": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/compressible": {
+            "version": "2.0.18",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/compression": {
+            "version": "1.7.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/compression/node_modules/debug": {
+            "version": "2.6.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/compression/node_modules/ms": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/concat-map": {
+            "version": "0.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/connect-history-api-fallback": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/content-disposition": {
+            "version": "0.5.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/content-type": {
+            "version": "1.0.5",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/cookie": {
+            "version": "0.7.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/cookie-signature": {
+            "version": "1.0.6",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/core-js-compat": {
+            "version": "3.41.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.24.4"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
+            }
+        },
+        "../clingo-wasm/node_modules/core-util-is": {
+            "version": "1.0.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/create-jest": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.9",
+                "jest-config": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "prompts": "^2.0.1"
+            },
+            "bin": {
+                "create-jest": "bin/create-jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "../clingo-wasm/node_modules/debug": {
+            "version": "4.4.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/dedent": {
+            "version": "1.5.3",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "babel-plugin-macros": "^3.1.0"
+            },
+            "peerDependenciesMeta": {
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/deep-extend": {
+            "version": "0.6.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/deepmerge": {
+            "version": "4.3.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/default-browser": {
+            "version": "5.2.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/default-browser-id": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/depd": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/destroy": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "../clingo-wasm/node_modules/detect-newline": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/detect-node": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/diff-sequences": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/dir-glob": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/dns-packet": {
+            "version": "5.6.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@leichtgewicht/ip-codec": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "../clingo-wasm/node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/ee-first": {
+            "version": "1.1.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/electron-to-chromium": {
+            "version": "1.5.116",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/email-addresses": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/emittery": {
+            "version": "0.13.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/emojis-list": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "../clingo-wasm/node_modules/encodeurl": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/enhanced-resolve": {
+            "version": "5.18.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "../clingo-wasm/node_modules/envinfo": {
+            "version": "7.14.0",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "envinfo": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/error-ex": {
+            "version": "1.3.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "../clingo-wasm/node_modules/es-define-property": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "../clingo-wasm/node_modules/es-errors": {
+            "version": "1.3.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "../clingo-wasm/node_modules/es-module-lexer": {
+            "version": "1.6.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "../clingo-wasm/node_modules/escalade": {
+            "version": "3.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/escape-html": {
+            "version": "1.0.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/esprima": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/esrecurse": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "../clingo-wasm/node_modules/esrecurse/node_modules/estraverse": {
+            "version": "5.3.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "../clingo-wasm/node_modules/estraverse": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "../clingo-wasm/node_modules/esutils": {
+            "version": "2.0.3",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/etag": {
+            "version": "1.8.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/eventemitter3": {
+            "version": "4.0.7",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/events": {
+            "version": "3.3.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "../clingo-wasm/node_modules/execa": {
+            "version": "5.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/exit": {
+            "version": "0.1.2",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/expect": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/expect-utils": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/exports-loader": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">= 18.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/express": {
+            "version": "4.21.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.8",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.20.3",
+                "content-disposition": "0.5.4",
+                "content-type": "~1.0.4",
+                "cookie": "0.7.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "1.3.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "merge-descriptors": "1.0.3",
+                "methods": "~1.1.2",
+                "on-finished": "2.4.1",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "0.1.12",
+                "proxy-addr": "~2.0.7",
+                "qs": "6.13.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.2.1",
+                "send": "0.19.0",
+                "serve-static": "1.16.2",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "../clingo-wasm/node_modules/express/node_modules/content-disposition": {
+            "version": "0.5.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/express/node_modules/debug": {
+            "version": "2.6.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/express/node_modules/ms": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/express/node_modules/path-to-regexp": {
+            "version": "0.1.12",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/express/node_modules/range-parser": {
+            "version": "1.2.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/express/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/fast-glob": {
+            "version": "3.3.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "../clingo-wasm/node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/fast-uri": {
+            "version": "3.0.6",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "../clingo-wasm/node_modules/fastest-levenshtein": {
+            "version": "1.0.16",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.9.1"
+            }
+        },
+        "../clingo-wasm/node_modules/fastq": {
+            "version": "1.19.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "../clingo-wasm/node_modules/faye-websocket": {
+            "version": "0.11.4",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "websocket-driver": ">=0.5.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/fb-watchman": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bser": "2.1.1"
+            }
+        },
+        "../clingo-wasm/node_modules/file-loader": {
+            "version": "6.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^4.0.0 || ^5.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/filename-reserved-regex": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/filenamify": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.1",
+                "trim-repeated": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/fill-range": {
+            "version": "7.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/finalhandler": {
+            "version": "1.3.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "on-finished": "2.4.1",
+                "parseurl": "~1.3.3",
+                "statuses": "2.0.1",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/finalhandler/node_modules/debug": {
+            "version": "2.6.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/finalhandler/node_modules/ms": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/find-cache-dir": {
+            "version": "3.3.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/find-up": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/flat": {
+            "version": "5.0.2",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
+        "../clingo-wasm/node_modules/follow-redirects": {
+            "version": "1.15.9",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/foreground-child": {
+            "version": "3.3.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "../clingo-wasm/node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "../clingo-wasm/node_modules/forwarded": {
+            "version": "0.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/fresh": {
+            "version": "0.5.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/fs-extra": {
+            "version": "11.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
+        "../clingo-wasm/node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/function-bind": {
+            "version": "1.1.2",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "../clingo-wasm/node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/get-package-type": {
+            "version": "0.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/get-proto": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "../clingo-wasm/node_modules/get-stream": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/gh-pages": {
+            "version": "6.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "async": "^3.2.4",
+                "commander": "^13.0.0",
+                "email-addresses": "^5.0.0",
+                "filenamify": "^4.3.0",
+                "find-cache-dir": "^3.3.1",
+                "fs-extra": "^11.1.1",
+                "globby": "^11.1.0"
+            },
+            "bin": {
+                "gh-pages": "bin/gh-pages.js",
+                "gh-pages-clean": "bin/gh-pages-clean.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/glob": {
+            "version": "7.2.3",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "../clingo-wasm/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "../clingo-wasm/node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "../clingo-wasm/node_modules/globals": {
+            "version": "11.12.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/globby": {
+            "version": "11.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/gopd": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/handle-thing": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/has-flag": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/has-symbols": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/hasown": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "../clingo-wasm/node_modules/hpack.js": {
+            "version": "2.1.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            }
+        },
+        "../clingo-wasm/node_modules/hpack.js/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "../clingo-wasm/node_modules/hpack.js/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "../clingo-wasm/node_modules/html-escaper": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/http-deceiver": {
+            "version": "1.2.7",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/http-errors": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "2.0.0",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/http-parser-js": {
+            "version": "0.5.9",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/http-proxy": {
+            "version": "1.18.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/http-proxy-middleware": {
+            "version": "2.0.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-proxy": "^1.17.8",
+                "http-proxy": "^1.18.1",
+                "is-glob": "^4.0.1",
+                "is-plain-obj": "^3.0.0",
+                "micromatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "@types/express": "^4.17.13"
+            },
+            "peerDependenciesMeta": {
+                "@types/express": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/human-signals": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
+        "../clingo-wasm/node_modules/hyperdyperid": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.18"
+            }
+        },
+        "../clingo-wasm/node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/ignore": {
+            "version": "5.3.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "../clingo-wasm/node_modules/import-local": {
+            "version": "3.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pkg-dir": "^4.2.0",
+                "resolve-cwd": "^3.0.0"
+            },
+            "bin": {
+                "import-local-fixture": "fixtures/cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
+        "../clingo-wasm/node_modules/inflight": {
+            "version": "1.0.6",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "../clingo-wasm/node_modules/inherits": {
+            "version": "2.0.4",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/ini": {
+            "version": "1.3.8",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/interpret": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "../clingo-wasm/node_modules/ipaddr.js": {
+            "version": "2.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "../clingo-wasm/node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/is-core-module": {
+            "version": "2.16.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/is-docker": {
+            "version": "2.2.1",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/is-extglob": {
+            "version": "2.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/is-generator-fn": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/is-glob": {
+            "version": "4.0.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/is-inside-container/node_modules/is-docker": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/is-network-error": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/is-number": {
+            "version": "7.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "../clingo-wasm/node_modules/is-plain-obj": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/is-plain-object": {
+            "version": "2.0.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "isobject": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/is-port-reachable": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/is-stream": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/is-wsl": {
+            "version": "2.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/isarray": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/isexe": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/isobject": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/istanbul-lib-instrument": {
+            "version": "6.0.3",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@babel/core": "^7.23.9",
+                "@babel/parser": "^7.23.9",
+                "@istanbuljs/schema": "^0.1.3",
+                "istanbul-lib-coverage": "^3.2.0",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/istanbul-lib-instrument/node_modules/semver": {
+            "version": "7.7.1",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/istanbul-lib-report/node_modules/make-dir": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/istanbul-lib-report/node_modules/semver": {
+            "version": "7.7.1",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/istanbul-lib-source-maps": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/istanbul-reports": {
+            "version": "3.1.7",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/jackspeak": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "../clingo-wasm/node_modules/jest": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/core": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "import-local": "^3.0.2",
+                "jest-cli": "^29.7.0"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/jest-changed-files": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^5.0.0",
+                "jest-util": "^29.7.0",
+                "p-limit": "^3.1.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-circus": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/expect": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "co": "^4.6.0",
+                "dedent": "^1.0.0",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^29.7.0",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "p-limit": "^3.1.0",
+                "pretty-format": "^29.7.0",
+                "pure-rand": "^6.0.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-cli": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/core": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "create-jest": "^29.7.0",
+                "exit": "^0.1.2",
+                "import-local": "^3.0.2",
+                "jest-config": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "yargs": "^17.3.1"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/jest-config": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.11.6",
+                "@jest/test-sequencer": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "babel-jest": "^29.7.0",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.2.0",
+                "deepmerge": "^4.2.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "jest-circus": "^29.7.0",
+                "jest-environment-node": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-runner": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "parse-json": "^5.2.0",
+                "pretty-format": "^29.7.0",
+                "slash": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "ts-node": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/jest-diff": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^29.6.3",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-docblock": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-each": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^29.6.3",
+                "jest-util": "^29.7.0",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-environment-node": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "jest-mock": "^29.7.0",
+                "jest-util": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-get-type": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-haste-map": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/graceful-fs": "^4.1.3",
+                "@types/node": "*",
+                "anymatch": "^3.0.3",
+                "fb-watchman": "^2.0.0",
+                "graceful-fs": "^4.2.9",
+                "jest-regex-util": "^29.6.3",
+                "jest-util": "^29.7.0",
+                "jest-worker": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "walker": "^1.0.8"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.2"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-leak-detector": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-matcher-utils": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "jest-diff": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-message-util": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.12.13",
+                "@jest/types": "^29.6.3",
+                "@types/stack-utils": "^2.0.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.9",
+                "micromatch": "^4.0.4",
+                "pretty-format": "^29.7.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-mock": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "jest-util": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-pnp-resolver": {
+            "version": "1.2.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "peerDependencies": {
+                "jest-resolve": "*"
+            },
+            "peerDependenciesMeta": {
+                "jest-resolve": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/jest-regex-util": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-resolve": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "jest-pnp-resolver": "^1.2.2",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "resolve": "^1.20.0",
+                "resolve.exports": "^2.0.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-resolve-dependencies": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jest-regex-util": "^29.6.3",
+                "jest-snapshot": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-runner": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/console": "^29.7.0",
+                "@jest/environment": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "emittery": "^0.13.1",
+                "graceful-fs": "^4.2.9",
+                "jest-docblock": "^29.7.0",
+                "jest-environment-node": "^29.7.0",
+                "jest-haste-map": "^29.7.0",
+                "jest-leak-detector": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-resolve": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-watcher": "^29.7.0",
+                "jest-worker": "^29.7.0",
+                "p-limit": "^3.1.0",
+                "source-map-support": "0.5.13"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-runtime": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/globals": "^29.7.0",
+                "@jest/source-map": "^29.6.3",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "cjs-module-lexer": "^1.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-mock": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-snapshot": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.11.6",
+                "@babel/generator": "^7.7.2",
+                "@babel/plugin-syntax-jsx": "^7.7.2",
+                "@babel/plugin-syntax-typescript": "^7.7.2",
+                "@babel/types": "^7.3.3",
+                "@jest/expect-utils": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "babel-preset-current-node-syntax": "^1.0.0",
+                "chalk": "^4.0.0",
+                "expect": "^29.7.0",
+                "graceful-fs": "^4.2.9",
+                "jest-diff": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^29.7.0",
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-snapshot/node_modules/semver": {
+            "version": "7.7.1",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-util": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.2.0",
+                "graceful-fs": "^4.2.9",
+                "picomatch": "^2.2.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-validate": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "camelcase": "^6.2.0",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^29.6.3",
+                "leven": "^3.1.0",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-validate/node_modules/camelcase": {
+            "version": "6.3.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-watcher": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "emittery": "^0.13.1",
+                "jest-util": "^29.7.0",
+                "string-length": "^4.0.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-worker": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "jest-util": "^29.7.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/js-tokens": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "../clingo-wasm/node_modules/jsesc": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/json5": {
+            "version": "2.2.3",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "../clingo-wasm/node_modules/kind-of": {
+            "version": "6.0.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/kleur": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/launch-editor": {
+            "version": "2.10.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "shell-quote": "^1.8.1"
+            }
+        },
+        "../clingo-wasm/node_modules/leven": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/loader-runner": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.11.5"
+            }
+        },
+        "../clingo-wasm/node_modules/loader-utils": {
+            "version": "2.0.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
+        },
+        "../clingo-wasm/node_modules/locate-path": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/lodash.debounce": {
+            "version": "4.0.8",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "../clingo-wasm/node_modules/make-dir": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/makeerror": {
+            "version": "1.0.12",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tmpl": "1.0.5"
+            }
+        },
+        "../clingo-wasm/node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "../clingo-wasm/node_modules/media-typer": {
+            "version": "0.3.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/memfs": {
+            "version": "4.17.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/json-pack": "^1.0.3",
+                "@jsonjoy.com/util": "^1.3.0",
+                "tree-dump": "^1.0.1",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            }
+        },
+        "../clingo-wasm/node_modules/merge-descriptors": {
+            "version": "1.0.3",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/merge-stream": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/merge2": {
+            "version": "1.4.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "../clingo-wasm/node_modules/methods": {
+            "version": "1.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/micromatch": {
+            "version": "4.0.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "../clingo-wasm/node_modules/mime": {
+            "version": "1.6.0",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/mime-db": {
+            "version": "1.53.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/mime-types": {
+            "version": "2.1.35",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/mime-types/node_modules/mime-db": {
+            "version": "1.52.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/minimatch": {
+            "version": "3.1.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/minimist": {
+            "version": "1.2.8",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/minipass": {
+            "version": "7.1.2",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "../clingo-wasm/node_modules/ms": {
+            "version": "2.1.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/multicast-dns": {
+            "version": "7.2.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dns-packet": "^5.2.2",
+                "thunky": "^1.0.2"
+            },
+            "bin": {
+                "multicast-dns": "cli.js"
+            }
+        },
+        "../clingo-wasm/node_modules/natural-compare": {
+            "version": "1.4.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/negotiator": {
+            "version": "0.6.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/neo-async": {
+            "version": "2.6.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/node-forge": {
+            "version": "1.3.1",
+            "dev": true,
+            "license": "(BSD-3-Clause OR GPL-2.0)",
+            "engines": {
+                "node": ">= 6.13.0"
+            }
+        },
+        "../clingo-wasm/node_modules/node-int64": {
+            "version": "0.4.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/node-releases": {
+            "version": "2.0.19",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/normalize-path": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/object-inspect": {
+            "version": "1.13.4",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/obuf": {
+            "version": "1.1.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/on-finished": {
+            "version": "2.4.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/on-headers": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/once": {
+            "version": "1.4.0",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "../clingo-wasm/node_modules/onetime": {
+            "version": "5.1.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/open": {
+            "version": "10.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/open/node_modules/is-wsl": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/p-limit": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/p-locate": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/p-locate/node_modules/p-limit": {
+            "version": "2.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/p-retry": {
+            "version": "6.2.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/retry": "0.12.2",
+                "is-network-error": "^1.0.0",
+                "retry": "^0.13.1"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/p-try": {
+            "version": "2.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
+        "../clingo-wasm/node_modules/parse-json": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/parseurl": {
+            "version": "1.3.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/path-exists": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/path-is-inside": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "(WTFPL OR MIT)"
+        },
+        "../clingo-wasm/node_modules/path-key": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/path-parse": {
+            "version": "1.0.7",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/path-scurry": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "../clingo-wasm/node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "11.0.2",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "../clingo-wasm/node_modules/path-to-regexp": {
+            "version": "3.3.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/path-type": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/picocolors": {
+            "version": "1.1.1",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/picomatch": {
+            "version": "2.3.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "../clingo-wasm/node_modules/pirates": {
+            "version": "4.0.6",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "../clingo-wasm/node_modules/pkg-dir": {
+            "version": "4.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/pretty-format": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "^29.6.3",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^18.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/prompts": {
+            "version": "2.4.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "../clingo-wasm/node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "../clingo-wasm/node_modules/proxy-addr/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "../clingo-wasm/node_modules/punycode": {
+            "version": "2.3.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/pure-rand": {
+            "version": "6.1.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/qs": {
+            "version": "6.13.0",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.0.6"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/randombytes": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "../clingo-wasm/node_modules/range-parser": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/raw-body": {
+            "version": "2.5.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/raw-body/node_modules/bytes": {
+            "version": "3.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/rc": {
+            "version": "1.2.8",
+            "dev": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "../clingo-wasm/node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/react-is": {
+            "version": "18.3.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "../clingo-wasm/node_modules/readdirp": {
+            "version": "3.6.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/rechoir": {
+            "version": "0.8.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve": "^1.20.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "../clingo-wasm/node_modules/regenerate": {
+            "version": "1.4.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/regenerate-unicode-properties": {
+            "version": "10.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regenerate": "^1.4.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/regexpu-core": {
+            "version": "6.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regenerate": "^1.4.2",
+                "regenerate-unicode-properties": "^10.2.0",
+                "regjsgen": "^0.8.0",
+                "regjsparser": "^0.12.0",
+                "unicode-match-property-ecmascript": "^2.0.0",
+                "unicode-match-property-value-ecmascript": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/registry-auth-token": {
+            "version": "3.3.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "../clingo-wasm/node_modules/registry-url": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "rc": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/regjsgen": {
+            "version": "0.8.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/regjsparser": {
+            "version": "0.12.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "jsesc": "~3.0.2"
+            },
+            "bin": {
+                "regjsparser": "bin/parser"
+            }
+        },
+        "../clingo-wasm/node_modules/regjsparser/node_modules/jsesc": {
+            "version": "3.0.2",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/require-directory": {
+            "version": "2.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/require-from-string": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/requires-port": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/resolve": {
+            "version": "1.22.10",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-core-module": "^2.16.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/resolve-cwd": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/resolve-from": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/resolve.exports": {
+            "version": "2.0.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/retry": {
+            "version": "0.13.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "../clingo-wasm/node_modules/reusify": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/rimraf": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^11.0.0",
+                "package-json-from-dist": "^1.0.0"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "../clingo-wasm/node_modules/rimraf/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/rimraf/node_modules/glob": {
+            "version": "11.0.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^4.0.1",
+                "minimatch": "^10.0.0",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "../clingo-wasm/node_modules/rimraf/node_modules/minimatch": {
+            "version": "10.0.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "../clingo-wasm/node_modules/run-applescript": {
+            "version": "7.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/run-parallel": {
+            "version": "1.2.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
+        "../clingo-wasm/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/schema-utils": {
+            "version": "3.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "../clingo-wasm/node_modules/select-hose": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/selfsigned": {
+            "version": "2.4.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node-forge": "^1.3.0",
+                "node-forge": "^1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/semver": {
+            "version": "6.3.1",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "../clingo-wasm/node_modules/send": {
+            "version": "0.19.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/send/node_modules/debug": {
+            "version": "2.6.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/send/node_modules/debug/node_modules/ms": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/send/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/send/node_modules/range-parser": {
+            "version": "1.2.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/serialize-javascript": {
+            "version": "6.0.2",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "../clingo-wasm/node_modules/serve": {
+            "version": "14.2.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@zeit/schemas": "2.36.0",
+                "ajv": "8.12.0",
+                "arg": "5.0.2",
+                "boxen": "7.0.0",
+                "chalk": "5.0.1",
+                "chalk-template": "0.4.0",
+                "clipboardy": "3.0.0",
+                "compression": "1.7.4",
+                "is-port-reachable": "4.0.0",
+                "serve-handler": "6.1.6",
+                "update-check": "1.5.4"
+            },
+            "bin": {
+                "serve": "build/main.js"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "../clingo-wasm/node_modules/serve-handler": {
+            "version": "6.1.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.0.0",
+                "content-disposition": "0.5.2",
+                "mime-types": "2.1.18",
+                "minimatch": "3.1.2",
+                "path-is-inside": "1.0.2",
+                "path-to-regexp": "3.3.0",
+                "range-parser": "1.2.0"
+            }
+        },
+        "../clingo-wasm/node_modules/serve-handler/node_modules/mime-db": {
+            "version": "1.33.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/serve-handler/node_modules/mime-types": {
+            "version": "2.1.18",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "~1.33.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/serve-index": {
+            "version": "1.9.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.4",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/serve-index/node_modules/debug": {
+            "version": "2.6.9",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/serve-index/node_modules/depd": {
+            "version": "1.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/serve-index/node_modules/http-errors": {
+            "version": "1.6.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/serve-index/node_modules/inherits": {
+            "version": "2.0.3",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/serve-index/node_modules/ms": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/serve-index/node_modules/setprototypeof": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/serve-index/node_modules/statuses": {
+            "version": "1.5.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/serve-static": {
+            "version": "1.16.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.19.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/serve/node_modules/ajv": {
+            "version": "8.12.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "../clingo-wasm/node_modules/serve/node_modules/chalk": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/serve/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/shallow-clone": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "kind-of": "^6.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/shebang-command": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/shell-quote": {
+            "version": "1.8.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/side-channel": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/sisteransi": {
+            "version": "1.0.5",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/slash": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/sockjs": {
+            "version": "0.3.24",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "faye-websocket": "^0.11.3",
+                "uuid": "^8.3.2",
+                "websocket-driver": "^0.7.4"
+            }
+        },
+        "../clingo-wasm/node_modules/source-map": {
+            "version": "0.6.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/source-map-support": {
+            "version": "0.5.13",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "../clingo-wasm/node_modules/spdy": {
+            "version": "4.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
+                "http-deceiver": "^1.2.7",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/spdy-transport": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
+            }
+        },
+        "../clingo-wasm/node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "../clingo-wasm/node_modules/stack-utils": {
+            "version": "2.0.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/statuses": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "../clingo-wasm/node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/string-length": {
+            "version": "4.0.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "char-regex": "^1.0.2",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/string-width": {
+            "version": "5.1.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/string-width/node_modules/ansi-regex": {
+            "version": "6.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/string-width/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/strip-bom": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/strip-outer": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/strip-outer/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/supports-color": {
+            "version": "7.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "../clingo-wasm/node_modules/tapable": {
+            "version": "2.2.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "../clingo-wasm/node_modules/terser": {
+            "version": "5.39.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.8.2",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/terser-webpack-plugin": {
+            "version": "5.3.14",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^4.3.0",
+                "serialize-javascript": "^6.0.2",
+                "terser": "^5.31.1"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/ajv": {
+            "version": "8.17.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/jest-worker": {
+            "version": "27.5.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "../clingo-wasm/node_modules/terser-webpack-plugin/node_modules/supports-color": {
+            "version": "8.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/terser/node_modules/commander": {
+            "version": "2.20.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/terser/node_modules/source-map-support": {
+            "version": "0.5.21",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "../clingo-wasm/node_modules/test-exclude": {
+            "version": "6.0.0",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/thingies": {
+            "version": "1.21.0",
+            "dev": true,
+            "license": "Unlicense",
+            "engines": {
+                "node": ">=10.18"
+            },
+            "peerDependencies": {
+                "tslib": "^2"
+            }
+        },
+        "../clingo-wasm/node_modules/thunky": {
+            "version": "1.1.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/tmpl": {
+            "version": "1.0.5",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "../clingo-wasm/node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/toidentifier": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/tree-dump": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "../clingo-wasm/node_modules/trim-repeated": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "../clingo-wasm/node_modules/trim-repeated/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/ts-loader": {
+            "version": "9.5.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "enhanced-resolve": "^5.0.0",
+                "micromatch": "^4.0.0",
+                "semver": "^7.3.4",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "typescript": "*",
+                "webpack": "^5.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/ts-loader/node_modules/semver": {
+            "version": "7.7.1",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/ts-loader/node_modules/source-map": {
+            "version": "0.7.4",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "../clingo-wasm/node_modules/tslib": {
+            "version": "2.8.1",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "../clingo-wasm/node_modules/type-detect": {
+            "version": "4.0.8",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/type-fest": {
+            "version": "0.21.3",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/type-is": {
+            "version": "1.6.18",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/typescript": {
+            "version": "5.8.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "../clingo-wasm/node_modules/undici-types": {
+            "version": "6.21.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/unicode-canonical-property-names-ecmascript": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/unicode-match-property-ecmascript": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "unicode-canonical-property-names-ecmascript": "^2.0.0",
+                "unicode-property-aliases-ecmascript": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/unicode-match-property-value-ecmascript": {
+            "version": "2.2.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/unicode-property-aliases-ecmascript": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "../clingo-wasm/node_modules/universalify": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/unpipe": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/update-browserslist-db": {
+            "version": "1.1.3",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "../clingo-wasm/node_modules/update-check": {
+            "version": "1.5.4",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "registry-auth-token": "3.3.2",
+                "registry-url": "3.1.0"
+            }
+        },
+        "../clingo-wasm/node_modules/uri-js": {
+            "version": "4.4.1",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "../clingo-wasm/node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/utils-merge": {
+            "version": "1.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "../clingo-wasm/node_modules/uuid": {
+            "version": "8.3.2",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "../clingo-wasm/node_modules/v8-to-istanbul": {
+            "version": "9.3.0",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.12",
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.12.0"
+            }
+        },
+        "../clingo-wasm/node_modules/vary": {
+            "version": "1.1.2",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "../clingo-wasm/node_modules/walker": {
+            "version": "1.0.8",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "makeerror": "1.0.12"
+            }
+        },
+        "../clingo-wasm/node_modules/watchpack": {
+            "version": "2.4.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "../clingo-wasm/node_modules/wbuf": {
+            "version": "1.7.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack": {
+            "version": "5.99.7",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/eslint-scope": "^3.7.7",
+                "@types/estree": "^1.0.6",
+                "@types/json-schema": "^7.0.15",
+                "@webassemblyjs/ast": "^1.14.1",
+                "@webassemblyjs/wasm-edit": "^1.14.1",
+                "@webassemblyjs/wasm-parser": "^1.14.1",
+                "acorn": "^8.14.0",
+                "browserslist": "^4.24.0",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.17.1",
+                "es-module-lexer": "^1.2.1",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.11",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.2.0",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^4.3.2",
+                "tapable": "^2.1.1",
+                "terser-webpack-plugin": "^5.3.11",
+                "watchpack": "^2.4.1",
+                "webpack-sources": "^3.2.3"
+            },
+            "bin": {
+                "webpack": "bin/webpack.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependenciesMeta": {
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-cli": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@discoveryjs/json-ext": "^0.6.1",
+                "@webpack-cli/configtest": "^3.0.1",
+                "@webpack-cli/info": "^3.0.1",
+                "@webpack-cli/serve": "^3.0.1",
+                "colorette": "^2.0.14",
+                "commander": "^12.1.0",
+                "cross-spawn": "^7.0.3",
+                "envinfo": "^7.14.0",
+                "fastest-levenshtein": "^1.0.12",
+                "import-local": "^3.0.2",
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
+                "webpack-merge": "^6.0.1"
+            },
+            "bin": {
+                "webpack-cli": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.82.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack-bundle-analyzer": {
+                    "optional": true
+                },
+                "webpack-dev-server": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-cli/node_modules/commander": {
+            "version": "12.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-middleware": {
+            "version": "7.4.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "colorette": "^2.0.10",
+                "memfs": "^4.6.0",
+                "mime-types": "^2.1.31",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "schema-utils": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 18.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/ajv": {
+            "version": "8.17.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/range-parser": {
+            "version": "1.2.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-middleware/node_modules/schema-utils": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-server": {
+            "version": "5.2.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/bonjour": "^3.5.13",
+                "@types/connect-history-api-fallback": "^1.5.4",
+                "@types/express": "^4.17.21",
+                "@types/express-serve-static-core": "^4.17.21",
+                "@types/serve-index": "^1.9.4",
+                "@types/serve-static": "^1.15.5",
+                "@types/sockjs": "^0.3.36",
+                "@types/ws": "^8.5.10",
+                "ansi-html-community": "^0.0.8",
+                "bonjour-service": "^1.2.1",
+                "chokidar": "^3.6.0",
+                "colorette": "^2.0.10",
+                "compression": "^1.7.4",
+                "connect-history-api-fallback": "^2.0.0",
+                "express": "^4.21.2",
+                "graceful-fs": "^4.2.6",
+                "http-proxy-middleware": "^2.0.7",
+                "ipaddr.js": "^2.1.0",
+                "launch-editor": "^2.6.1",
+                "open": "^10.0.3",
+                "p-retry": "^6.2.0",
+                "schema-utils": "^4.2.0",
+                "selfsigned": "^2.4.1",
+                "serve-index": "^1.9.1",
+                "sockjs": "^0.3.24",
+                "spdy": "^4.0.2",
+                "webpack-dev-middleware": "^7.4.2",
+                "ws": "^8.18.0"
+            },
+            "bin": {
+                "webpack-dev-server": "bin/webpack-dev-server.js"
+            },
+            "engines": {
+                "node": ">= 18.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                },
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.6",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/ajv": {
+            "version": "8.17.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/webpack-dev-server/node_modules/schema-utils": {
+            "version": "4.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-merge": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack-sources": {
+            "version": "3.2.3",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack/node_modules/ajv": {
+            "version": "8.17.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "../clingo-wasm/node_modules/webpack/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/webpack/node_modules/schema-utils": {
+            "version": "4.3.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "../clingo-wasm/node_modules/websocket-driver": {
+            "version": "0.7.4",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "http-parser-js": ">=0.5.1",
+                "safe-buffer": ">=5.1.0",
+                "websocket-extensions": ">=0.1.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/websocket-extensions": {
+            "version": "0.1.4",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "../clingo-wasm/node_modules/which": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "../clingo-wasm/node_modules/widest-line": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "../clingo-wasm/node_modules/wildcard": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/worker-loader": {
+            "version": "3.0.8",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^4.0.0 || ^5.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "6.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "../clingo-wasm/node_modules/wrappy": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/write-file-atomic": {
+            "version": "4.0.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.7"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "../clingo-wasm/node_modules/ws": {
+            "version": "8.18.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "../clingo-wasm/node_modules/y18n": {
+            "version": "5.0.8",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "../clingo-wasm/node_modules/yallist": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "ISC"
+        },
+        "../clingo-wasm/node_modules/yargs": {
+            "version": "17.7.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "../clingo-wasm/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "../clingo-wasm/node_modules/yargs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "../clingo-wasm/node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "../clingo-wasm/node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -65,24 +8612,21 @@
         },
         "node_modules/@azu/format-text": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
-            "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@azu/style-format": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
-            "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
             "dev": true,
+            "license": "WTFPL",
             "dependencies": {
                 "@azu/format-text": "^1.0.1"
             }
         },
         "node_modules/@azure/abort-controller": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -92,9 +8636,8 @@
         },
         "node_modules/@azure/core-auth": {
             "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
-            "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-util": "^1.11.0",
@@ -106,9 +8649,8 @@
         },
         "node_modules/@azure/core-client": {
             "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.4.tgz",
-            "integrity": "sha512-f7IxTD15Qdux30s2qFARH+JxgwxWLG2Rlr4oSkPGuLWm+1p5y1+C04XGLA0vmX6EtqfutmjvpNmAfgwVIS5hpw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.4.0",
@@ -124,9 +8666,8 @@
         },
         "node_modules/@azure/core-rest-pipeline": {
             "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.21.0.tgz",
-            "integrity": "sha512-a4MBwe/5WKbq9MIxikzgxLBbruC5qlkFYlBdI7Ev50Y7ib5Vo/Jvt5jnJo7NaWeJ908LCHL0S1Us4UMf1VoTfg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.8.0",
@@ -142,9 +8683,8 @@
         },
         "node_modules/@azure/core-tracing": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
-            "integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -154,9 +8694,8 @@
         },
         "node_modules/@azure/core-util": {
             "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.12.0.tgz",
-            "integrity": "sha512-13IyjTQgABPARvG90+N2dXpC+hwp466XCdQXPCRlbWHgd3SJd5Q1VvaBGv6k1BIa4MQm6hAF1UBU1m8QUxV8sQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@typespec/ts-http-runtime": "^0.2.2",
@@ -168,9 +8707,8 @@
         },
         "node_modules/@azure/identity": {
             "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.10.1.tgz",
-            "integrity": "sha512-YM/z6RxRtFlXUH2egAYF/FDPes+MUE6ZoknjEdaq7ebJMMNUzn9zCJ3bd2ZZZlkP0r1xKa88kolhFH/FGV7JnA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.9.0",
@@ -190,9 +8728,8 @@
         },
         "node_modules/@azure/logger": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.2.0.tgz",
-            "integrity": "sha512-0hKEzLhpw+ZTAfNJyRrn6s+V0nDWzXk9OjBr2TiGIu0OfMr5s2V4FpKLTAK3Ca5r5OKLbf4hkOGDPyiRjie/jA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@typespec/ts-http-runtime": "^0.2.2",
                 "tslib": "^2.6.2"
@@ -203,9 +8740,8 @@
         },
         "node_modules/@azure/msal-browser": {
             "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.13.2.tgz",
-            "integrity": "sha512-lS75bF6FYZRwsacKLXc8UYu/jb+gOB7dtZq5938chCvV/zKTFDnzuXxCXhsSUh0p8s/P8ztgbfdueD9lFARQlQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azure/msal-common": "15.7.1"
             },
@@ -215,18 +8751,16 @@
         },
         "node_modules/@azure/msal-common": {
             "version": "15.7.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.7.1.tgz",
-            "integrity": "sha512-a0eowoYfRfKZEjbiCoA5bPT3IlWRAdGSvi63OU23Hv+X6EI8gbvXCoeqokUceFMoT9NfRUWTJSx5FiuzruqT8g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-node": {
             "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.6.1.tgz",
-            "integrity": "sha512-ctcVz4xS+st5KxOlQqgpvA+uDFAa59CvkmumnuhlD2XmNczloKBdCiMQG7/TigSlaeHe01qoOlDjz3TyUAmKUg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azure/msal-common": "15.7.1",
                 "jsonwebtoken": "^9.0.0",
@@ -238,9 +8772,8 @@
         },
         "node_modules/@babel/code-frame": {
             "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.25.9",
                 "js-tokens": "^4.0.0",
@@ -252,18 +8785,16 @@
         },
         "node_modules/@babel/compat-data": {
             "version": "7.26.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-            "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
             "version": "7.26.10",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
-            "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -291,18 +8822,16 @@
         },
         "node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/generator": {
             "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-            "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.27.0",
                 "@babel/types": "^7.27.0",
@@ -316,9 +8845,8 @@
         },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-            "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/compat-data": "^7.26.8",
                 "@babel/helper-validator-option": "^7.25.9",
@@ -332,33 +8860,29 @@
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "yallist": "^3.0.2"
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/traverse": "^7.25.9",
                 "@babel/types": "^7.25.9"
@@ -369,9 +8893,8 @@
         },
         "node_modules/@babel/helper-module-transforms": {
             "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.25.9",
                 "@babel/helper-validator-identifier": "^7.25.9",
@@ -386,45 +8909,40 @@
         },
         "node_modules/@babel/helper-plugin-utils": {
             "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
             "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
             "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-            "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.27.0",
                 "@babel/types": "^7.27.0"
@@ -435,9 +8953,8 @@
         },
         "node_modules/@babel/parser": {
             "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-            "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.27.0"
             },
@@ -450,9 +8967,8 @@
         },
         "node_modules/@babel/plugin-syntax-async-generators": {
             "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -462,9 +8978,8 @@
         },
         "node_modules/@babel/plugin-syntax-bigint": {
             "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -474,9 +8989,8 @@
         },
         "node_modules/@babel/plugin-syntax-class-properties": {
             "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.12.13"
             },
@@ -486,9 +9000,8 @@
         },
         "node_modules/@babel/plugin-syntax-class-static-block": {
             "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -501,9 +9014,8 @@
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
             "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-            "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.25.9"
             },
@@ -516,9 +9028,8 @@
         },
         "node_modules/@babel/plugin-syntax-import-meta": {
             "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -528,9 +9039,8 @@
         },
         "node_modules/@babel/plugin-syntax-json-strings": {
             "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -540,9 +9050,8 @@
         },
         "node_modules/@babel/plugin-syntax-jsx": {
             "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-            "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.25.9"
             },
@@ -555,9 +9064,8 @@
         },
         "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
             "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -567,9 +9075,8 @@
         },
         "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
             "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -579,9 +9086,8 @@
         },
         "node_modules/@babel/plugin-syntax-numeric-separator": {
             "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -591,9 +9097,8 @@
         },
         "node_modules/@babel/plugin-syntax-object-rest-spread": {
             "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -603,9 +9108,8 @@
         },
         "node_modules/@babel/plugin-syntax-optional-catch-binding": {
             "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -615,9 +9119,8 @@
         },
         "node_modules/@babel/plugin-syntax-optional-chaining": {
             "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -627,9 +9130,8 @@
         },
         "node_modules/@babel/plugin-syntax-private-property-in-object": {
             "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -642,9 +9144,8 @@
         },
         "node_modules/@babel/plugin-syntax-top-level-await": {
             "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-            "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -657,9 +9158,8 @@
         },
         "node_modules/@babel/plugin-syntax-typescript": {
             "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-            "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.25.9"
             },
@@ -672,9 +9172,8 @@
         },
         "node_modules/@babel/template": {
             "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-            "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.26.2",
                 "@babel/parser": "^7.27.0",
@@ -686,9 +9185,8 @@
         },
         "node_modules/@babel/traverse": {
             "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-            "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.26.2",
                 "@babel/generator": "^7.27.0",
@@ -704,18 +9202,16 @@
         },
         "node_modules/@babel/traverse/node_modules/globals": {
             "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/@babel/types": {
             "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-            "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.25.9",
                 "@babel/helper-validator-identifier": "^7.25.9"
@@ -726,30 +9222,26 @@
         },
         "node_modules/@bazel/runfiles": {
             "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.3.1.tgz",
-            "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
-            "dev": true
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@isaacs/balanced-match": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "20 || >=22"
             }
         },
         "node_modules/@isaacs/brace-expansion": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@isaacs/balanced-match": "^4.0.1"
             },
@@ -759,8 +9251,6 @@
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -777,9 +9267,8 @@
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
@@ -793,27 +9282,24 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
             "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
             "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -824,9 +9310,8 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
             "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -837,9 +9322,8 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -849,9 +9333,8 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -864,9 +9347,8 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -876,27 +9358,24 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@jest/console": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
-            "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -911,9 +9390,8 @@
         },
         "node_modules/@jest/core": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-            "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/console": "^29.7.0",
                 "@jest/reporters": "^29.7.0",
@@ -958,18 +9436,16 @@
         },
         "node_modules/@jest/core/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@jest/core/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -979,9 +9455,8 @@
         },
         "node_modules/@jest/environment": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-            "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/fake-timers": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -994,9 +9469,8 @@
         },
         "node_modules/@jest/expect": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
-            "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "expect": "^29.7.0",
                 "jest-snapshot": "^29.7.0"
@@ -1007,9 +9481,8 @@
         },
         "node_modules/@jest/expect-utils": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-            "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "jest-get-type": "^29.6.3"
             },
@@ -1019,9 +9492,8 @@
         },
         "node_modules/@jest/fake-timers": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-            "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@sinonjs/fake-timers": "^10.0.2",
@@ -1036,9 +9508,8 @@
         },
         "node_modules/@jest/globals": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-            "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/expect": "^29.7.0",
@@ -1051,9 +9522,8 @@
         },
         "node_modules/@jest/reporters": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-            "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@jest/console": "^29.7.0",
@@ -1094,19 +9564,16 @@
         },
         "node_modules/@jest/reporters/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@jest/reporters/node_modules/glob": {
             "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -1124,9 +9591,8 @@
         },
         "node_modules/@jest/reporters/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -1136,9 +9602,8 @@
         },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -1148,9 +9613,8 @@
         },
         "node_modules/@jest/source-map": {
             "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-            "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.18",
                 "callsites": "^3.0.0",
@@ -1162,9 +9626,8 @@
         },
         "node_modules/@jest/test-result": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
-            "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/console": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -1177,9 +9640,8 @@
         },
         "node_modules/@jest/test-sequencer": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-            "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/test-result": "^29.7.0",
                 "graceful-fs": "^4.2.9",
@@ -1192,9 +9654,8 @@
         },
         "node_modules/@jest/transform": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-            "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@jest/types": "^29.6.3",
@@ -1218,9 +9679,8 @@
         },
         "node_modules/@jest/types": {
             "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1235,9 +9695,8 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-            "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1249,33 +9708,29 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/set-array": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1283,9 +9738,8 @@
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -1296,18 +9750,16 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -1318,9 +9770,8 @@
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=14"
@@ -1328,9 +9779,8 @@
         },
         "node_modules/@redhat-developer/locators": {
             "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/@redhat-developer/locators/-/locators-1.13.0.tgz",
-            "integrity": "sha512-+v+FtxaPnCDguiwiU+UpWiNFaEyBXpRQMbf35SlJVAT5Yszb6qnDOFf9iTwtZNeeny4Cv+PVlYmoe/u9bRqByw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peerDependencies": {
                 "@redhat-developer/page-objects": ">=1.0.0",
                 "selenium-webdriver": ">=4.6.1"
@@ -1338,9 +9788,8 @@
         },
         "node_modules/@redhat-developer/page-objects": {
             "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/@redhat-developer/page-objects/-/page-objects-1.13.0.tgz",
-            "integrity": "sha512-k53UVbw/5cD1dh1uagwGX48t7vtx9mqysaKEnx9hjuAaxHJ7aKF5KfF25mi31fvn6xvEdEvpBPrV2yoRgyD6Gg==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "clipboardy": "^4.0.0",
                 "clone-deep": "^4.0.1",
@@ -1355,15 +9804,13 @@
         },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@secretlint/config-creator": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.1.1.tgz",
-            "integrity": "sha512-TJ42CHZqqnEe9ORvIXVVMqdu3KAtyZRxLspjFexo6XgrwJ6CoFHQYzIihilqRjo2sJh9HMrpnYSj/5hopofGrA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@secretlint/types": "^10.1.1"
             },
@@ -1373,9 +9820,8 @@
         },
         "node_modules/@secretlint/config-loader": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.1.1.tgz",
-            "integrity": "sha512-jBClVFmS6Yu/zI5ejBCRF5a5ASYsE4gOjogjB+WsaHbQHtGvnyY7I26Qtdg4ihCc/VPKYQg0LdM75pLTXzwsjg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@secretlint/profiler": "^10.1.1",
                 "@secretlint/resolver": "^10.1.1",
@@ -1390,9 +9836,8 @@
         },
         "node_modules/@secretlint/core": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.1.1.tgz",
-            "integrity": "sha512-COLCxSoH/iVQdLeaZPVtBj0UWKOagO09SqYkCQgfFfZ+soGxKVK405dL317r4PnH9Pm8/s8xQC6OSY5rWTRObQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@secretlint/profiler": "^10.1.1",
                 "@secretlint/types": "^10.1.1",
@@ -1405,9 +9850,8 @@
         },
         "node_modules/@secretlint/formatter": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.1.1.tgz",
-            "integrity": "sha512-Gpd8gTPN121SJ0h/9e6nWlZU7PitfhXUiEzW7Kyswg6kNGs+bSqmgTgWFtbo1VQ4ygJYiveWPNT05RCImBexJw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@secretlint/resolver": "^10.1.1",
                 "@secretlint/types": "^10.1.1",
@@ -1427,18 +9871,16 @@
         },
         "node_modules/@secretlint/formatter/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@secretlint/formatter/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -1448,9 +9890,8 @@
         },
         "node_modules/@secretlint/node": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.1.1.tgz",
-            "integrity": "sha512-AhN+IGqljVObm8a+B33b23FY79wihu5E61Nd3oYSoZV7SxUvMjpafqhLfpt4frNSY7Ghf/pirWu7JY7GMujFrA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@secretlint/config-loader": "^10.1.1",
                 "@secretlint/core": "^10.1.1",
@@ -1467,30 +9908,26 @@
         },
         "node_modules/@secretlint/profiler": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.1.1.tgz",
-            "integrity": "sha512-kReI+Wr7IQz0LbVwYByzlnPbx4BEF2oEWJBc4Oa45g24alCjHu+jD9h9mzkTJqYUgMnVYD3o7HfzeqxFrV+9XA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@secretlint/resolver": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.1.1.tgz",
-            "integrity": "sha512-GdQzxnBtdBRjBULvZ8ERkaRqDp0njVwXrzBCav1pb0XshVk76C1cjeDqtTqM4RJ1Awo/g5U5MIWYztYv67v5Gg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@secretlint/secretlint-formatter-sarif": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.1.1.tgz",
-            "integrity": "sha512-Dyq8nzy6domjSlZKX1E5PEzuWxeTqjQJWrlXBmVmOjwLBLfRZDlm5Vq+AduBmEk03KEIKIZi4cZQwsniuRPO9Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "node-sarif-builder": "^2.0.3"
             }
         },
         "node_modules/@secretlint/secretlint-rule-no-dotenv": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.1.1.tgz",
-            "integrity": "sha512-a3/sOUUtEHuw1HCadtxUjViNeomiiohfJj+rwtHxJkCq4pjITS3HSYhQBXnNvkctQNljKIzFm7JUA/4QJ6I4sQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@secretlint/types": "^10.1.1"
             },
@@ -1500,18 +9937,16 @@
         },
         "node_modules/@secretlint/secretlint-rule-preset-recommend": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.1.1.tgz",
-            "integrity": "sha512-+GeISCXVgpnoeRZE4ZPsuO97+fm6z8Ge23LNq6LvR9ZJAq018maXVftkJhHj4hnvYB5URUAEerBBkPGNk5/Ong==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=20.0.0"
             }
         },
         "node_modules/@secretlint/source-creator": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.1.1.tgz",
-            "integrity": "sha512-IWjvHcE0bhC/x88a9M9jbZlFRZGUEbBzujxrs2KzI5IQ2BXTBRBRhRSjE/BEpWqDHILB22c3mfam8X+UjukphA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@secretlint/types": "^10.1.1",
                 "istextorbinary": "^9.5.0"
@@ -1522,24 +9957,21 @@
         },
         "node_modules/@secretlint/types": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.1.1.tgz",
-            "integrity": "sha512-/JGAvVkurVHkargk3AC7UxRy+Ymc+52AVBO/fZA5pShuLW2dX4O/rKc4n8cyhQiOb/3ym5ACSlLQuQ8apPfxrQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=20.0.0"
             }
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@sindresorhus/is": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.0.1.tgz",
-            "integrity": "sha512-QWLl2P+rsCJeofkDNIT3WFmb6NrRud1SUYW8dIhXK/46XFV8Q/g7Bsvib0Askb0reRLe+WYPeeE+l5cH7SlkuQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -1549,9 +9981,8 @@
         },
         "node_modules/@sindresorhus/merge-streams": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -1561,27 +9992,24 @@
         },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "type-detect": "4.0.8"
             }
         },
         "node_modules/@sinonjs/fake-timers": {
             "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
             }
         },
         "node_modules/@szmarczak/http-timer": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-            "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "defer-to-connect": "^2.0.1"
             },
@@ -1591,15 +10019,13 @@
         },
         "node_modules/@textlint/ast-node-types": {
             "version": "14.8.4",
-            "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-14.8.4.tgz",
-            "integrity": "sha512-+fI7miec/r9VeniFV9ppL4jRCmHNsTxieulTUf/4tvGII3db5hGriKHC4p/diq1SkQ9Sgs7kg6UyydxZtpTz1Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@textlint/linter-formatter": {
             "version": "14.8.4",
-            "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-14.8.4.tgz",
-            "integrity": "sha512-sZ0UfYRDBNHnfMVBqLqqYnqTB7Ec169ljlmo+SEHR1T+dHUPYy1/DZK4p7QREXlBSFL4cnkswETCbc9xRodm4Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azu/format-text": "^1.0.2",
                 "@azu/style-format": "^1.0.1",
@@ -1619,33 +10045,29 @@
         },
         "node_modules/@textlint/linter-formatter/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@textlint/linter-formatter/node_modules/argparse": {
             "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
         },
         "node_modules/@textlint/linter-formatter/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@textlint/linter-formatter/node_modules/js-yaml": {
             "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -1656,15 +10078,13 @@
         },
         "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
-            "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@textlint/linter-formatter/node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -1676,9 +10096,8 @@
         },
         "node_modules/@textlint/linter-formatter/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -1688,39 +10107,34 @@
         },
         "node_modules/@textlint/module-interop": {
             "version": "14.8.4",
-            "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-14.8.4.tgz",
-            "integrity": "sha512-1LdPYLAVpa27NOt6EqvuFO99s4XLB0c19Hw9xKSG6xQ1K82nUEyuWhzTQKb3KJ5Qx7qj14JlXZLfnEuL6A16Bw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@textlint/resolver": {
             "version": "14.8.4",
-            "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-14.8.4.tgz",
-            "integrity": "sha512-nMDOgDAVwNU9ommh+Db0U+MCMNDPbQ/1HBNjbnHwxZkCpcT6hsAJwBe38CW/DtWVUv8yeR4R40IYNPT84srNwA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@textlint/types": {
             "version": "14.8.4",
-            "resolved": "https://registry.npmjs.org/@textlint/types/-/types-14.8.4.tgz",
-            "integrity": "sha512-9nyY8vVXlr8hHKxa6+37omJhXWCwovMQcgMteuldYd4dOxGm14AK2nXdkgtKEUQnzLGaXy46xwLCfhQy7V7/YA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@textlint/ast-node-types": "14.8.4"
             }
         },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.20.7",
                 "@babel/types": "^7.20.7",
@@ -1731,18 +10145,16 @@
         },
         "node_modules/@types/babel__generator": {
             "version": "7.6.8",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
-            "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.0.0"
             }
         },
         "node_modules/@types/babel__template": {
             "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -1750,84 +10162,73 @@
         },
         "node_modules/@types/babel__traverse": {
             "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-            "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-            "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/http-cache-semantics": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-            "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-report": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-            "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/istanbul-lib-coverage": "*"
             }
         },
         "node_modules/@types/istanbul-reports": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-            "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
         },
         "node_modules/@types/mocha": {
             "version": "10.0.10",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
-            "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "22.14.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
-            "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/sarif": {
             "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
-            "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/selenium-webdriver": {
             "version": "4.1.28",
-            "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.1.28.tgz",
-            "integrity": "sha512-Au7CXegiS7oapbB16zxPToY4Cjzi9UQQMf3W2ZZM8PigMLTGR3iUAHjPUTddyE5g1SBjT/qpmvlsAQLBfNAdKg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "@types/ws": "*"
@@ -1835,39 +10236,34 @@
         },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-            "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/ws": {
             "version": "8.18.1",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.33",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
         },
         "node_modules/@types/yargs-parser": {
             "version": "21.0.3",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@typespec/ts-http-runtime": {
             "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.2.3.tgz",
-            "integrity": "sha512-oRhjSzcVjX8ExyaF8hC0zzTqxlVuRlgMHL/Bh4w3xB9+wjbm0FpXylVU/lBrn+kgphwYTrOk3tp+AVShGmlYCg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^7.0.0",
                 "https-proxy-agent": "^7.0.0",
@@ -1879,18 +10275,16 @@
         },
         "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
             "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/@typespec/ts-http-runtime/node_modules/http-proxy-agent": {
             "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -1901,9 +10295,8 @@
         },
         "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -1914,13 +10307,10 @@
         },
         "node_modules/@vscode/codicons": {
             "version": "0.0.36",
-            "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.36.tgz",
-            "integrity": "sha512-wsNOvNMMJ2BY8rC2N2MNBG7yOowV3ov8KlvUE/AiVUlHKTfWsw3OgAOQduX7h0Un6GssKD3aoTVH+TF3DSQwKQ=="
+            "license": "CC-BY-4.0"
         },
         "node_modules/@vscode/test-cli": {
             "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/@vscode/test-cli/-/test-cli-0.0.11.tgz",
-            "integrity": "sha512-qO332yvzFqGhBMJrp6TdwbIydiHgCtxXc2Nl6M58mbH/Z+0CyLR76Jzv4YWPEthhrARprzCRJUqzFvTHFhTj7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1943,18 +10333,16 @@
         },
         "node_modules/@vscode/test-cli/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
         "node_modules/@vscode/test-cli/node_modules/glob": {
             "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -1972,9 +10360,8 @@
         },
         "node_modules/@vscode/test-cli/node_modules/jackspeak": {
             "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
@@ -1987,15 +10374,13 @@
         },
         "node_modules/@vscode/test-cli/node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@vscode/test-cli/node_modules/minimatch": {
             "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -2008,9 +10393,8 @@
         },
         "node_modules/@vscode/test-cli/node_modules/path-scurry": {
             "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^10.2.0",
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -2024,9 +10408,8 @@
         },
         "node_modules/@vscode/test-cli/node_modules/supports-color": {
             "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
-            "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -2036,9 +10419,8 @@
         },
         "node_modules/@vscode/test-electron": {
             "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.1.tgz",
-            "integrity": "sha512-Gc6EdaLANdktQ1t+zozoBVRynfIsMKMc94Svu1QreOBC8y76x4tvaK32TljrLi1LI2+PK58sDVbL7ALdqf3VRQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.5",
@@ -2052,18 +10434,16 @@
         },
         "node_modules/@vscode/test-electron/node_modules/agent-base": {
             "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/@vscode/test-electron/node_modules/http-proxy-agent": {
             "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -2074,9 +10454,8 @@
         },
         "node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -2087,9 +10466,8 @@
         },
         "node_modules/@vscode/vsce": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.6.0.tgz",
-            "integrity": "sha512-u2ZoMfymRNJb14aHNawnXJtXHLXDVKc1oKZaH4VELKT/9iWKRVgtQOdwxCgtwSxJoqYvuK4hGlBWQJ05wxADhg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.1.0",
                 "@secretlint/node": "^10.1.1",
@@ -2133,10 +10511,9 @@
         },
         "node_modules/@vscode/vsce-sign": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.6.tgz",
-            "integrity": "sha512-j9Ashk+uOWCDHYDxgGsqzKq5FXW9b9MW7QqOIYZ8IYpneJclWTBeHZz2DJCSKQgo+JAqNcaRRE1hzIx0dswqAw==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "SEE LICENSE IN LICENSE.txt",
             "optionalDependencies": {
                 "@vscode/vsce-sign-alpine-arm64": "2.0.5",
                 "@vscode/vsce-sign-alpine-x64": "2.0.5",
@@ -2149,118 +10526,13 @@
                 "@vscode/vsce-sign-win32-x64": "2.0.5"
             }
         },
-        "node_modules/@vscode/vsce-sign-alpine-arm64": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.5.tgz",
-            "integrity": "sha512-XVmnF40APwRPXSLYA28Ye+qWxB25KhSVpF2eZVtVOs6g7fkpOxsVnpRU1Bz2xG4ySI79IRuapDJoAQFkoOgfdQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "alpine"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-alpine-x64": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.5.tgz",
-            "integrity": "sha512-JuxY3xcquRsOezKq6PEHwCgd1rh1GnhyH6urVEWUzWn1c1PC4EOoyffMD+zLZtFuZF5qR1I0+cqDRNKyPvpK7Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "alpine"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-darwin-arm64": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.5.tgz",
-            "integrity": "sha512-z2Q62bk0ptADFz8a0vtPvnm6vxpyP3hIEYMU+i1AWz263Pj8Mc38cm/4sjzxu+LIsAfhe9HzvYNS49lV+KsatQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-darwin-x64": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.5.tgz",
-            "integrity": "sha512-ma9JDC7FJ16SuPXlLKkvOD2qLsmW/cKfqK4zzM2iJE1PbckF3BlR08lYqHV89gmuoTpYB55+z8Y5Fz4wEJBVDA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-linux-arm": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.5.tgz",
-            "integrity": "sha512-cdCwtLGmvC1QVrkIsyzv01+o9eR+wodMJUZ9Ak3owhcGxPRB53/WvrDHAFYA6i8Oy232nuen1YqWeEohqBuSzA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-linux-arm64": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.5.tgz",
-            "integrity": "sha512-Hr1o0veBymg9SmkCqYnfaiUnes5YK6k/lKFA5MhNmiEN5fNqxyPUCdRZMFs3Ajtx2OFW4q3KuYVRwGA7jdLo7Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-linux-x64": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.5.tgz",
-            "integrity": "sha512-XLT0gfGMcxk6CMRLDkgqEPTyG8Oa0OFe1tPv2RVbphSOjFWJwZgK3TYWx39i/7gqpDHlax0AP6cgMygNJrA6zg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@vscode/vsce-sign-win32-arm64": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.5.tgz",
-            "integrity": "sha512-hco8eaoTcvtmuPhavyCZhrk5QIcLiyAUhEso87ApAWDllG7djIrWiOCtqn48k4pHz+L8oCQlE0nwNHfcYcxOPw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
         "node_modules/@vscode/vsce-sign-win32-x64": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.5.tgz",
-            "integrity": "sha512-1ixKFGM2FwM+6kQS2ojfY3aAelICxjiCzeg4nTHpkeU1Tfs4RC+lVLrgq5NwcBC7ZLr6UfY3Ct3D6suPeOf7BQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
             "os": [
                 "win32"
@@ -2268,18 +10540,16 @@
         },
         "node_modules/@vscode/vsce/node_modules/commander": {
             "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "debug": "4"
             },
@@ -2289,8 +10559,7 @@
         },
         "node_modules/ajv": {
             "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2304,9 +10573,8 @@
         },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -2319,9 +10587,8 @@
         },
         "node_modules/ansi-escapes/node_modules/type-fest": {
             "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true,
+            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
             },
@@ -2331,8 +10598,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2344,9 +10609,8 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -2359,9 +10623,8 @@
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -2372,30 +10635,26 @@
         },
         "node_modules/argparse": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "dev": true,
+            "license": "Python-2.0"
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/azure-devops-node-api": {
             "version": "12.5.0",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
-            "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",
                 "typed-rest-client": "^1.8.4"
@@ -2403,9 +10662,8 @@
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-            "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/transform": "^29.7.0",
                 "@types/babel__core": "^7.1.14",
@@ -2424,9 +10682,8 @@
         },
         "node_modules/babel-plugin-istanbul": {
             "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-            "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -2440,9 +10697,8 @@
         },
         "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
             "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-            "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@babel/core": "^7.12.3",
                 "@babel/parser": "^7.14.7",
@@ -2456,18 +10712,16 @@
         },
         "node_modules/babel-plugin-istanbul/node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/babel-plugin-jest-hoist": {
             "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-            "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.3.3",
                 "@babel/types": "^7.3.3",
@@ -2480,9 +10734,8 @@
         },
         "node_modules/babel-preset-current-node-syntax": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-            "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
                 "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -2506,9 +10759,8 @@
         },
         "node_modules/babel-preset-jest": {
             "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-            "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "babel-plugin-jest-hoist": "^29.6.3",
                 "babel-preset-current-node-syntax": "^1.0.0"
@@ -2522,14 +10774,11 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true,
             "funding": [
                 {
@@ -2544,35 +10793,30 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/big-integer": {
             "version": "1.6.52",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-            "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
             "dev": true,
+            "license": "Unlicense",
             "engines": {
                 "node": ">=0.6"
             }
         },
         "node_modules/binary": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -2582,9 +10826,8 @@
         },
         "node_modules/binaryextensions": {
             "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
-            "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
             "dev": true,
+            "license": "Artistic-2.0",
             "dependencies": {
                 "editions": "^6.21.0"
             },
@@ -2597,9 +10840,8 @@
         },
         "node_modules/bl": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-            "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer": "^6.0.3",
                 "inherits": "^2.0.4",
@@ -2608,9 +10850,8 @@
         },
         "node_modules/bl/node_modules/readable-stream": {
             "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -2622,27 +10863,23 @@
         },
         "node_modules/bluebird": {
             "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/boundary": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
-            "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2650,9 +10887,8 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -2662,14 +10898,11 @@
         },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/browserslist": {
             "version": "4.24.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
             "funding": [
                 {
@@ -2685,6 +10918,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -2700,17 +10934,14 @@
         },
         "node_modules/bser": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "node-int64": "^0.4.0"
             }
         },
         "node_modules/buffer": {
             "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
             "dev": true,
             "funding": [
                 {
@@ -2726,6 +10957,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
@@ -2733,9 +10965,8 @@
         },
         "node_modules/buffer-alloc": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer-alloc-unsafe": "^1.1.0",
                 "buffer-fill": "^1.0.0"
@@ -2743,50 +10974,42 @@
         },
         "node_modules/buffer-alloc-unsafe": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/buffer-fill": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/buffer-indexof-polyfill": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10"
             }
         },
         "node_modules/buffers": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
             "dev": true,
             "engines": {
                 "node": ">=0.2.0"
@@ -2794,9 +11017,8 @@
         },
         "node_modules/bundle-name": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "run-applescript": "^7.0.0"
             },
@@ -2809,9 +11031,8 @@
         },
         "node_modules/c8": {
             "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
-            "integrity": "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@istanbuljs/schema": "^0.1.3",
@@ -2834,18 +11055,16 @@
         },
         "node_modules/cacheable-lookup": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             }
         },
         "node_modules/cacheable-request": {
             "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-12.0.1.tgz",
-            "integrity": "sha512-Yo9wGIQUaAfIbk+qY0X4cDQgCosecfBe3V9NSyeY4qPC2SAkbCS4Xj79VP8WOzitpJUZKc/wsRCYF5ariDIwkg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/http-cache-semantics": "^4.0.4",
                 "get-stream": "^9.0.1",
@@ -2861,9 +11080,8 @@
         },
         "node_modules/cacheable-request/node_modules/get-stream": {
             "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@sec-ant/readable-stream": "^0.4.1",
                 "is-stream": "^4.0.1"
@@ -2877,9 +11095,8 @@
         },
         "node_modules/cacheable-request/node_modules/is-stream": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -2889,9 +11106,8 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2"
@@ -2902,9 +11118,8 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "get-intrinsic": "^1.3.0"
@@ -2918,18 +11133,16 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/camelcase": {
             "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -2939,8 +11152,6 @@
         },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001707",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-            "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
             "dev": true,
             "funding": [
                 {
@@ -2955,25 +11166,21 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ]
+            ],
+            "license": "CC-BY-4.0"
         },
         "node_modules/chainsaw": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
             "dev": true,
+            "license": "MIT/X11",
             "dependencies": {
                 "traverse": ">=0.3.0 <0.4"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2987,18 +11194,16 @@
         },
         "node_modules/char-regex": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/cheerio": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
-            "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cheerio-select": "^2.1.0",
                 "dom-serializer": "^2.0.0",
@@ -3021,9 +11226,8 @@
         },
         "node_modules/cheerio-select": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-            "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-select": "^5.1.0",
@@ -3038,9 +11242,8 @@
         },
         "node_modules/chokidar": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -3062,14 +11265,11 @@
         },
         "node_modules/chownr": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/ci-info": {
             "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
             "dev": true,
             "funding": [
                 {
@@ -3077,21 +11277,20 @@
                     "url": "https://github.com/sponsors/sibiraj-s"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/cjs-module-lexer": {
             "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cli-cursor": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "restore-cursor": "^4.0.0"
             },
@@ -3104,9 +11303,8 @@
         },
         "node_modules/cli-spinners": {
             "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             },
@@ -3120,9 +11318,8 @@
         },
         "node_modules/clipboardy": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
-            "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "execa": "^8.0.1",
                 "is-wsl": "^3.1.0",
@@ -3137,9 +11334,8 @@
         },
         "node_modules/cliui": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.1",
@@ -3151,24 +11347,21 @@
         },
         "node_modules/cliui/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/cliui/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cliui/node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -3180,9 +11373,8 @@
         },
         "node_modules/cliui/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -3192,9 +11384,8 @@
         },
         "node_modules/cliui/node_modules/wrap-ansi": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -3209,9 +11400,8 @@
         },
         "node_modules/clone-deep": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-plain-object": "^2.0.4",
                 "kind-of": "^6.0.2",
@@ -3223,9 +11413,8 @@
         },
         "node_modules/co": {
             "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "iojs": ">= 1.0.0",
                 "node": ">= 0.12.0"
@@ -3233,24 +11422,21 @@
         },
         "node_modules/cockatiel": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
-            "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/collect-v8-coverage": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-            "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -3260,15 +11446,13 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -3278,42 +11462,36 @@
         },
         "node_modules/commander": {
             "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-            "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=20"
             }
         },
         "node_modules/compare-versions": {
             "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
-            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/create-jest": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
-            "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "chalk": "^4.0.0",
@@ -3332,9 +11510,8 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -3346,15 +11523,13 @@
         },
         "node_modules/cross-spawn/node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/cross-spawn/node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -3367,9 +11542,8 @@
         },
         "node_modules/css-select": {
             "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-what": "^6.1.0",
@@ -3383,9 +11557,8 @@
         },
         "node_modules/css-what": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">= 6"
             },
@@ -3395,9 +11568,8 @@
         },
         "node_modules/debug": {
             "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -3412,9 +11584,8 @@
         },
         "node_modules/decamelize": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -3424,9 +11595,8 @@
         },
         "node_modules/decompress-response": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "mimic-response": "^3.1.0"
             },
@@ -3439,9 +11609,8 @@
         },
         "node_modules/decompress-response/node_modules/mimic-response": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -3451,9 +11620,8 @@
         },
         "node_modules/dedent": {
             "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-            "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
             "dev": true,
+            "license": "MIT",
             "peerDependencies": {
                 "babel-plugin-macros": "^3.1.0"
             },
@@ -3465,9 +11633,8 @@
         },
         "node_modules/deep-extend": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=4.0.0"
@@ -3475,18 +11642,16 @@
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/default-browser": {
             "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bundle-name": "^4.1.0",
                 "default-browser-id": "^5.0.0"
@@ -3500,9 +11665,8 @@
         },
         "node_modules/default-browser-id": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -3512,18 +11676,16 @@
         },
         "node_modules/defer-to-connect": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/define-lazy-prop": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -3533,18 +11695,16 @@
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
         },
         "node_modules/detect-libc": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-            "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "engines": {
                 "node": ">=8"
@@ -3552,17 +11712,14 @@
         },
         "node_modules/detect-newline": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/diff": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -3571,18 +11728,16 @@
         },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/dom-serializer": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.2",
@@ -3594,21 +11749,19 @@
         },
         "node_modules/domelementtype": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
             "dev": true,
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/fb55"
                 }
-            ]
+            ],
+            "license": "BSD-2-Clause"
         },
         "node_modules/domhandler": {
             "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "domelementtype": "^2.3.0"
             },
@@ -3621,9 +11774,8 @@
         },
         "node_modules/domutils": {
             "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
@@ -3635,9 +11787,8 @@
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -3649,34 +11800,29 @@
         },
         "node_modules/duplexer2": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "readable-stream": "^2.0.2"
             }
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/editions": {
             "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/editions/-/editions-6.21.0.tgz",
-            "integrity": "sha512-ofkXJtn7z0urokN62DI3SBo/5xAtF0rR7tn+S/bSYV79Ka8pTajIIl+fFQ1q88DQEImymmo97M4azY3WX/nUdg==",
             "dev": true,
+            "license": "Artistic-2.0",
             "dependencies": {
                 "version-range": "^4.13.0"
             },
@@ -3689,15 +11835,13 @@
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.129",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.129.tgz",
-            "integrity": "sha512-JlXUemX4s0+9f8mLqib/bHH8gOHf5elKS6KeWG3sk3xozb/JTq/RLXIv8OKUWiK4Ah00Wm88EFj5PYkFr4RUPA==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/emittery": {
             "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-            "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -3707,16 +11851,13 @@
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/encoding-sniffer": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-            "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "whatwg-encoding": "^3.1.1"
@@ -3727,18 +11868,16 @@
         },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
             }
         },
         "node_modules/enhanced-resolve": {
             "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-            "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -3749,9 +11888,8 @@
         },
         "node_modules/entities": {
             "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -3761,36 +11899,32 @@
         },
         "node_modules/error-ex": {
             "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
             },
@@ -3800,9 +11934,8 @@
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -3815,18 +11948,16 @@
         },
         "node_modules/escalade": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -3836,9 +11967,8 @@
         },
         "node_modules/esprima": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -3849,9 +11979,8 @@
         },
         "node_modules/execa": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^8.0.1",
@@ -3872,9 +12001,8 @@
         },
         "node_modules/execa/node_modules/mimic-fn": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -3884,9 +12012,8 @@
         },
         "node_modules/execa/node_modules/onetime": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^4.0.0"
             },
@@ -3899,8 +12026,6 @@
         },
         "node_modules/exit": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-            "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
@@ -3908,9 +12033,8 @@
         },
         "node_modules/expand-template": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
             "dev": true,
+            "license": "(MIT OR WTFPL)",
             "optional": true,
             "engines": {
                 "node": ">=6"
@@ -3918,9 +12042,8 @@
         },
         "node_modules/expect": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-            "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/expect-utils": "^29.7.0",
                 "jest-get-type": "^29.6.3",
@@ -3934,14 +12057,12 @@
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+            "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -3955,14 +12076,11 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-uri": {
             "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
             "funding": [
                 {
                     "type": "github",
@@ -3972,40 +12090,37 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fastify"
                 }
-            ]
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
             "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
             }
         },
         "node_modules/fb-watchman": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-            "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "bser": "2.1.1"
             }
         },
         "node_modules/fd-slicer": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
             }
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -4015,9 +12130,8 @@
         },
         "node_modules/find-up": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -4031,17 +12145,14 @@
         },
         "node_modules/flat": {
             "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "bin": {
                 "flat": "cli.js"
             }
         },
         "node_modules/foreground-child": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4057,9 +12168,8 @@
         },
         "node_modules/form-data": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-            "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -4073,24 +12183,21 @@
         },
         "node_modules/form-data-encoder": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.0.2.tgz",
-            "integrity": "sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fs-extra": {
             "version": "11.3.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -4102,30 +12209,13 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
+            "license": "ISC"
         },
         "node_modules/fstream": {
             "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "deprecated": "This package is no longer supported.",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -4138,10 +12228,8 @@
         },
         "node_modules/fstream/node_modules/glob": {
             "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -4159,10 +12247,8 @@
         },
         "node_modules/fstream/node_modules/rimraf": {
             "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -4172,36 +12258,32 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true,
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
@@ -4223,18 +12305,16 @@
         },
         "node_modules/get-package-type": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
             }
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -4245,9 +12325,8 @@
         },
         "node_modules/get-stream": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=16"
             },
@@ -4257,16 +12336,14 @@
         },
         "node_modules/github-from-package": {
             "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
             "dev": true,
+            "license": "MIT",
             "optional": true
         },
         "node_modules/glob": {
             "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-            "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.3.1",
                 "jackspeak": "^4.1.1",
@@ -4287,9 +12364,8 @@
         },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -4299,9 +12375,8 @@
         },
         "node_modules/glob/node_modules/minimatch": {
             "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-            "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@isaacs/brace-expansion": "^5.0.0"
             },
@@ -4314,9 +12389,8 @@
         },
         "node_modules/globby": {
             "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-            "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/merge-streams": "^2.1.0",
                 "fast-glob": "^3.3.3",
@@ -4334,9 +12408,8 @@
         },
         "node_modules/globby/node_modules/slash": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             },
@@ -4346,9 +12419,8 @@
         },
         "node_modules/globby/node_modules/unicorn-magic": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -4358,9 +12430,8 @@
         },
         "node_modules/gopd": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -4370,9 +12441,8 @@
         },
         "node_modules/got": {
             "version": "14.4.7",
-            "resolved": "https://registry.npmjs.org/got/-/got-14.4.7.tgz",
-            "integrity": "sha512-DI8zV1231tqiGzOiOzQWDhsBmncFW7oQDH6Zgy6pDPrqJuVZMtoSgPLLsBZQj8Jg4JFfwoOsDA8NGtLQLnIx2g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/is": "^7.0.1",
                 "@szmarczak/http-timer": "^5.0.1",
@@ -4395,24 +12465,21 @@
         },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -4422,9 +12489,8 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -4437,9 +12503,8 @@
         },
         "node_modules/hasown": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -4449,18 +12514,16 @@
         },
         "node_modules/he": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "he": "bin/he"
             }
         },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -4470,23 +12533,19 @@
         },
         "node_modules/hpagent": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
-            "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/html-escaper": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/htmlparser2": {
             "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-            "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
             "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -4495,6 +12554,7 @@
                     "url": "https://github.com/sponsors/fb55"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.3",
@@ -4504,9 +12564,8 @@
         },
         "node_modules/htmlparser2/node_modules/entities": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -4516,15 +12575,13 @@
         },
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy-agent": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@tootallnate/once": "1",
                 "agent-base": "6",
@@ -4536,9 +12593,8 @@
         },
         "node_modules/http2-wrapper": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "quick-lru": "^5.1.1",
                 "resolve-alpn": "^1.2.0"
@@ -4549,9 +12605,8 @@
         },
         "node_modules/https-proxy-agent": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -4562,18 +12617,16 @@
         },
         "node_modules/human-signals": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=16.17.0"
             }
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -4583,8 +12636,6 @@
         },
         "node_modules/ieee754": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "dev": true,
             "funding": [
                 {
@@ -4599,28 +12650,26 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
             "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
         },
         "node_modules/immediate": {
             "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/import-local": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
-            "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "pkg-dir": "^4.2.0",
                 "resolve-cwd": "^3.0.0"
@@ -4637,19 +12686,16 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
             }
         },
         "node_modules/inflight": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -4657,28 +12703,24 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/ini": {
             "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true,
+            "license": "ISC",
             "optional": true
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -4688,9 +12730,8 @@
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -4703,9 +12744,8 @@
         },
         "node_modules/is-docker": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -4718,17 +12758,14 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4737,18 +12774,16 @@
         },
         "node_modules/is-generator-fn": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -4758,9 +12793,8 @@
         },
         "node_modules/is-inside-container": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-docker": "^3.0.0"
             },
@@ -4776,9 +12810,8 @@
         },
         "node_modules/is-interactive": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -4788,27 +12821,24 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
             }
         },
         "node_modules/is-plain-obj": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/is-plain-object": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "isobject": "^3.0.1"
             },
@@ -4818,9 +12848,8 @@
         },
         "node_modules/is-stream": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -4830,9 +12859,8 @@
         },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -4842,9 +12870,8 @@
         },
         "node_modules/is-wsl": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-inside-container": "^1.0.0"
             },
@@ -4857,9 +12884,8 @@
         },
         "node_modules/is64bit": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
-            "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "system-architecture": "^0.1.0"
             },
@@ -4872,41 +12898,36 @@
         },
         "node_modules/isarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-            "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+            "license": "ISC",
             "engines": {
                 "node": ">=16"
             }
         },
         "node_modules/isobject": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/istanbul-lib-instrument": {
             "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-            "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@babel/core": "^7.23.9",
                 "@babel/parser": "^7.23.9",
@@ -4920,9 +12941,8 @@
         },
         "node_modules/istanbul-lib-report": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "istanbul-lib-coverage": "^3.0.0",
                 "make-dir": "^4.0.0",
@@ -4934,9 +12954,8 @@
         },
         "node_modules/istanbul-lib-source-maps": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-            "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "debug": "^4.1.1",
                 "istanbul-lib-coverage": "^3.0.0",
@@ -4948,9 +12967,8 @@
         },
         "node_modules/istanbul-reports": {
             "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-            "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
@@ -4961,9 +12979,8 @@
         },
         "node_modules/istextorbinary": {
             "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
-            "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
             "dev": true,
+            "license": "Artistic-2.0",
             "dependencies": {
                 "binaryextensions": "^6.11.0",
                 "editions": "^6.21.0",
@@ -4978,9 +12995,8 @@
         },
         "node_modules/jackspeak": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-            "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
             "dev": true,
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
@@ -4993,9 +13009,8 @@
         },
         "node_modules/jest": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-            "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -5019,9 +13034,8 @@
         },
         "node_modules/jest-changed-files": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
-            "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "execa": "^5.0.0",
                 "jest-util": "^29.7.0",
@@ -5033,9 +13047,8 @@
         },
         "node_modules/jest-changed-files/node_modules/execa": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -5056,9 +13069,8 @@
         },
         "node_modules/jest-changed-files/node_modules/get-stream": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -5068,18 +13080,16 @@
         },
         "node_modules/jest-changed-files/node_modules/human-signals": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
         "node_modules/jest-changed-files/node_modules/is-stream": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -5089,9 +13099,8 @@
         },
         "node_modules/jest-changed-files/node_modules/npm-run-path": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -5101,24 +13110,21 @@
         },
         "node_modules/jest-changed-files/node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/jest-changed-files/node_modules/strip-final-newline": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/jest-circus": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
-            "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/expect": "^29.7.0",
@@ -5147,9 +13153,8 @@
         },
         "node_modules/jest-cli": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
-            "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/test-result": "^29.7.0",
@@ -5180,9 +13185,8 @@
         },
         "node_modules/jest-config": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-            "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@jest/test-sequencer": "^29.7.0",
@@ -5225,10 +13229,8 @@
         },
         "node_modules/jest-config/node_modules/glob": {
             "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -5246,9 +13248,8 @@
         },
         "node_modules/jest-diff": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-            "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.0.0",
                 "diff-sequences": "^29.6.3",
@@ -5261,9 +13262,8 @@
         },
         "node_modules/jest-docblock": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-            "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "detect-newline": "^3.0.0"
             },
@@ -5273,9 +13273,8 @@
         },
         "node_modules/jest-each": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
-            "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "chalk": "^4.0.0",
@@ -5289,9 +13288,8 @@
         },
         "node_modules/jest-environment-node": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-            "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -5306,18 +13304,16 @@
         },
         "node_modules/jest-get-type": {
             "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-            "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-haste-map": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-            "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/graceful-fs": "^4.1.3",
@@ -5340,9 +13336,8 @@
         },
         "node_modules/jest-leak-detector": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-            "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "jest-get-type": "^29.6.3",
                 "pretty-format": "^29.7.0"
@@ -5353,9 +13348,8 @@
         },
         "node_modules/jest-matcher-utils": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-            "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.0.0",
                 "jest-diff": "^29.7.0",
@@ -5368,9 +13362,8 @@
         },
         "node_modules/jest-message-util": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-            "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@jest/types": "^29.6.3",
@@ -5388,9 +13381,8 @@
         },
         "node_modules/jest-mock": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-            "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -5402,9 +13394,8 @@
         },
         "node_modules/jest-pnp-resolver": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             },
@@ -5419,18 +13410,16 @@
         },
         "node_modules/jest-regex-util": {
             "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-            "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-resolve": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-            "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
@@ -5448,9 +13437,8 @@
         },
         "node_modules/jest-resolve-dependencies": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-            "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "jest-regex-util": "^29.6.3",
                 "jest-snapshot": "^29.7.0"
@@ -5461,9 +13449,8 @@
         },
         "node_modules/jest-runner": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-            "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/console": "^29.7.0",
                 "@jest/environment": "^29.7.0",
@@ -5493,9 +13480,8 @@
         },
         "node_modules/jest-runtime": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-            "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -5526,10 +13512,8 @@
         },
         "node_modules/jest-runtime/node_modules/glob": {
             "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -5547,9 +13531,8 @@
         },
         "node_modules/jest-snapshot": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-            "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@babel/generator": "^7.7.2",
@@ -5578,9 +13561,8 @@
         },
         "node_modules/jest-util": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-            "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -5595,9 +13577,8 @@
         },
         "node_modules/jest-validate": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-            "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "camelcase": "^6.2.0",
@@ -5612,9 +13593,8 @@
         },
         "node_modules/jest-watcher": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-            "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/test-result": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -5631,9 +13611,8 @@
         },
         "node_modules/jest-worker": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "jest-util": "^29.7.0",
@@ -5646,9 +13625,8 @@
         },
         "node_modules/jest-worker/node_modules/supports-color": {
             "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -5661,15 +13639,13 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -5679,9 +13655,8 @@
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -5691,26 +13666,22 @@
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+            "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -5720,15 +13691,13 @@
         },
         "node_modules/jsonc-parser": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
             },
@@ -5738,9 +13707,8 @@
         },
         "node_modules/jsonwebtoken": {
             "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "jws": "^3.2.2",
                 "lodash.includes": "^4.3.0",
@@ -5760,9 +13728,8 @@
         },
         "node_modules/jszip": {
             "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
             "dev": true,
+            "license": "(MIT OR GPL-3.0-or-later)",
             "dependencies": {
                 "lie": "~3.3.0",
                 "pako": "~1.0.2",
@@ -5772,9 +13739,8 @@
         },
         "node_modules/jwa": {
             "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-            "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer-equal-constant-time": "^1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -5783,9 +13749,8 @@
         },
         "node_modules/jws": {
             "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
@@ -5793,10 +13758,9 @@
         },
         "node_modules/keytar": {
             "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
-            "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "node-addon-api": "^4.3.0",
@@ -5805,75 +13769,66 @@
         },
         "node_modules/keyv": {
             "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/kleur": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/leven": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/lie": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "immediate": "~3.0.5"
             }
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/linkify-it": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
             }
         },
         "node_modules/listenercount": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -5886,63 +13841,53 @@
         },
         "node_modules/lodash": {
             "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.isboolean": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.isnumber": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.isstring": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
@@ -5956,9 +13901,8 @@
         },
         "node_modules/lowercase-keys": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -5968,9 +13912,8 @@
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -5980,9 +13923,8 @@
         },
         "node_modules/make-dir": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "semver": "^7.5.3"
             },
@@ -5995,18 +13937,16 @@
         },
         "node_modules/makeerror": {
             "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-            "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "tmpl": "1.0.5"
             }
         },
         "node_modules/markdown-it": {
             "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -6021,39 +13961,34 @@
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/mdurl": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -6064,9 +13999,8 @@
         },
         "node_modules/mime": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "mime": "cli.js"
             },
@@ -6076,18 +14010,16 @@
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
             "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -6097,18 +14029,16 @@
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/mimic-response": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -6118,9 +14048,8 @@
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -6130,17 +14059,14 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/minipass": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -6149,9 +14075,8 @@
         },
         "node_modules/mkdirp": {
             "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.6"
             },
@@ -6161,15 +14086,12 @@
         },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true,
+            "license": "MIT",
             "optional": true
         },
         "node_modules/mocha": {
             "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.5.0.tgz",
-            "integrity": "sha512-VKDjhy6LMTKm0WgNEdlY77YVsD49LZnPSXJAaPNL9NRYQADxvORsyG1DIQY6v53BKTnlNbEE2MbVCDbnxr4K3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6204,8 +14126,6 @@
         },
         "node_modules/mocha/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6214,8 +14134,6 @@
         },
         "node_modules/mocha/node_modules/chokidar": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6230,8 +14148,6 @@
         },
         "node_modules/mocha/node_modules/glob": {
             "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6251,8 +14167,6 @@
         },
         "node_modules/mocha/node_modules/jackspeak": {
             "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -6267,15 +14181,11 @@
         },
         "node_modules/mocha/node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/mocha/node_modules/minimatch": {
             "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6290,8 +14200,6 @@
         },
         "node_modules/mocha/node_modules/path-scurry": {
             "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -6307,8 +14215,6 @@
         },
         "node_modules/mocha/node_modules/readdirp": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6321,9 +14227,8 @@
         },
         "node_modules/mocha/node_modules/supports-color": {
             "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -6336,34 +14241,29 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/napi-build-utils": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
             "dev": true,
+            "license": "MIT",
             "optional": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/node-abi": {
             "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
-            "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "semver": "^7.3.5"
@@ -6374,28 +14274,24 @@
         },
         "node_modules/node-addon-api": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-            "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
             "dev": true,
+            "license": "MIT",
             "optional": true
         },
         "node_modules/node-int64": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-            "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/node-releases": {
             "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/node-sarif-builder": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-2.0.3.tgz",
-            "integrity": "sha512-Pzr3rol8fvhG/oJjIq2NTVB0vmdNNlz22FENhhPojYRZ4/ee08CfK4YuKmuL54V9MLhI1kpzxfOJ/63LzmZzDg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/sarif": "^2.1.4",
                 "fs-extra": "^10.0.0"
@@ -6406,9 +14302,8 @@
         },
         "node_modules/node-sarif-builder/node_modules/fs-extra": {
             "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -6420,9 +14315,8 @@
         },
         "node_modules/normalize-package-data": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^7.0.0",
                 "semver": "^7.3.5",
@@ -6434,9 +14328,8 @@
         },
         "node_modules/normalize-package-data/node_modules/hosted-git-info": {
             "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^10.0.1"
             },
@@ -6446,24 +14339,21 @@
         },
         "node_modules/normalize-package-data/node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/normalize-url": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-            "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             },
@@ -6473,9 +14363,8 @@
         },
         "node_modules/npm-run-path": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^4.0.0"
             },
@@ -6488,9 +14377,8 @@
         },
         "node_modules/npm-run-path/node_modules/path-key": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -6500,9 +14388,8 @@
         },
         "node_modules/nth-check": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0"
             },
@@ -6512,9 +14399,8 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6524,18 +14410,16 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
             }
         },
         "node_modules/onetime": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -6548,9 +14432,8 @@
         },
         "node_modules/open": {
             "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-            "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "default-browser": "^5.2.1",
                 "define-lazy-prop": "^3.0.0",
@@ -6566,9 +14449,8 @@
         },
         "node_modules/ora": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
-            "integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^5.3.0",
                 "cli-cursor": "^4.0.0",
@@ -6589,9 +14471,8 @@
         },
         "node_modules/ora/node_modules/chalk": {
             "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -6601,15 +14482,13 @@
         },
         "node_modules/ora/node_modules/emoji-regex": {
             "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ora/node_modules/is-unicode-supported": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -6619,9 +14498,8 @@
         },
         "node_modules/ora/node_modules/log-symbols": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-            "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^5.0.0",
                 "is-unicode-supported": "^1.1.0"
@@ -6635,9 +14513,8 @@
         },
         "node_modules/ora/node_modules/string-width": {
             "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
-            "integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^10.2.1",
@@ -6652,18 +14529,16 @@
         },
         "node_modules/p-cancelable": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
-            "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             }
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -6676,9 +14551,8 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -6691,9 +14565,8 @@
         },
         "node_modules/p-map": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-            "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -6703,31 +14576,26 @@
         },
         "node_modules/p-try": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
         "node_modules/pako": {
             "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-            "dev": true
+            "dev": true,
+            "license": "(MIT AND Zlib)"
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -6743,27 +14611,24 @@
         },
         "node_modules/parse-semver": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
-            "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "semver": "^5.1.0"
             }
         },
         "node_modules/parse-semver/node_modules/semver": {
             "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
             }
         },
         "node_modules/parse5": {
             "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0"
             },
@@ -6773,9 +14638,8 @@
         },
         "node_modules/parse5-htmlparser2-tree-adapter": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-            "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "domhandler": "^5.0.3",
                 "parse5": "^7.0.0"
@@ -6786,9 +14650,8 @@
         },
         "node_modules/parse5-parser-stream": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-            "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "parse5": "^7.0.0"
             },
@@ -6798,9 +14661,8 @@
         },
         "node_modules/parse5/node_modules/entities": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -6810,42 +14672,37 @@
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/path-scurry": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
             "dev": true,
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^11.0.0",
                 "minipass": "^7.1.2"
@@ -6859,18 +14716,16 @@
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
             "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-            "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": "20 || >=22"
             }
         },
         "node_modules/path-type": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-            "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -6880,21 +14735,18 @@
         },
         "node_modules/pend": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -6904,18 +14756,16 @@
         },
         "node_modules/pirates": {
             "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 6"
             }
         },
         "node_modules/pkg-dir": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "find-up": "^4.0.0"
             },
@@ -6925,9 +14775,8 @@
         },
         "node_modules/pkg-dir/node_modules/find-up": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -6938,9 +14787,8 @@
         },
         "node_modules/pkg-dir/node_modules/locate-path": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -6950,9 +14798,8 @@
         },
         "node_modules/pkg-dir/node_modules/p-limit": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -6965,9 +14812,8 @@
         },
         "node_modules/pkg-dir/node_modules/p-locate": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -6977,18 +14823,16 @@
         },
         "node_modules/pluralize": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/prebuild-install": {
             "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "detect-libc": "^2.0.0",
@@ -7013,9 +14857,8 @@
         },
         "node_modules/pretty-format": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -7027,9 +14870,8 @@
         },
         "node_modules/pretty-format/node_modules/ansi-styles": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -7039,15 +14881,13 @@
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/prompts": {
             "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "kleur": "^3.0.3",
                 "sisteransi": "^1.0.5"
@@ -7058,9 +14898,8 @@
         },
         "node_modules/pump": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -7069,17 +14908,14 @@
         },
         "node_modules/punycode.js": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/pure-rand": {
             "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
-            "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
             "dev": true,
             "funding": [
                 {
@@ -7090,13 +14926,13 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fast-check"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/qs": {
             "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
             },
@@ -7109,8 +14945,6 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true,
             "funding": [
                 {
@@ -7125,13 +14959,13 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/quick-lru": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -7141,18 +14975,16 @@
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
         },
         "node_modules/rc": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
             "optional": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
@@ -7166,9 +14998,8 @@
         },
         "node_modules/rc-config-loader": {
             "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
-            "integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.4",
                 "js-yaml": "^4.1.0",
@@ -7178,9 +15009,8 @@
         },
         "node_modules/rc/node_modules/strip-json-comments": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -7188,15 +15018,13 @@
         },
         "node_modules/react-is": {
             "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/read": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-            "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "mute-stream": "~0.0.4"
             },
@@ -7206,9 +15034,8 @@
         },
         "node_modules/read-pkg": {
             "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
-            "integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/normalize-package-data": "^2.4.1",
                 "normalize-package-data": "^6.0.0",
@@ -7224,27 +15051,24 @@
         },
         "node_modules/read-pkg/node_modules/json-parse-even-better-errors": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
-            "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/read-pkg/node_modules/lines-and-columns": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-            "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
         "node_modules/read-pkg/node_modules/parse-json": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
-            "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.21.4",
                 "error-ex": "^1.3.2",
@@ -7261,9 +15085,8 @@
         },
         "node_modules/read-pkg/node_modules/parse-json/node_modules/type-fest": {
             "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-            "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
             "dev": true,
+            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=14.16"
             },
@@ -7273,9 +15096,8 @@
         },
         "node_modules/readable-stream": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -7288,9 +15110,8 @@
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -7300,26 +15121,23 @@
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/require-from-string": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/resolve": {
             "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.0",
                 "path-parse": "^1.0.7",
@@ -7337,15 +15155,13 @@
         },
         "node_modules/resolve-alpn": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/resolve-cwd": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "resolve-from": "^5.0.0"
             },
@@ -7355,27 +15171,24 @@
         },
         "node_modules/resolve-cwd/node_modules/resolve-from": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/resolve.exports": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
-            "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/responselike": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
-            "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "lowercase-keys": "^3.0.0"
             },
@@ -7388,9 +15201,8 @@
         },
         "node_modules/restore-cursor": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "onetime": "^5.1.0",
                 "signal-exit": "^3.0.2"
@@ -7404,15 +15216,13 @@
         },
         "node_modules/restore-cursor/node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -7420,10 +15230,8 @@
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -7436,10 +15244,8 @@
         },
         "node_modules/rimraf/node_modules/glob": {
             "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -7457,9 +15263,8 @@
         },
         "node_modules/run-applescript": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -7469,8 +15274,6 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
             "funding": [
                 {
@@ -7486,42 +15289,38 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-            "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
             "dev": true,
+            "license": "WTFPL OR ISC",
             "dependencies": {
                 "truncate-utf8-bytes": "^1.0.0"
             }
         },
         "node_modules/sax": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/secretlint": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.1.1.tgz",
-            "integrity": "sha512-q50i+I9w6HH8P6o34LVq6M3hm5GZn2Eq5lYGHkEByOAbVqBHn8gsMGgyxjP1xSrSv1QjDtjxs/zKPm6JtkNzGw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@secretlint/config-creator": "^10.1.1",
                 "@secretlint/formatter": "^10.1.1",
@@ -7540,8 +15339,6 @@
         },
         "node_modules/selenium-webdriver": {
             "version": "4.34.0",
-            "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.34.0.tgz",
-            "integrity": "sha512-zGfQFcsASAv3KrYzYh+iw4fFqB7iZAgHW7BU6rRz7isK1i1X4x3LvjmZad4bUUgHDwTnAhlqTzDh21byB+zHMg==",
             "dev": true,
             "funding": [
                 {
@@ -7553,6 +15350,7 @@
                     "url": "https://opencollective.com/selenium"
                 }
             ],
+            "license": "Apache-2.0",
             "dependencies": {
                 "@bazel/runfiles": "^6.3.1",
                 "jszip": "^3.10.1",
@@ -7565,9 +15363,8 @@
         },
         "node_modules/semver": {
             "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -7577,24 +15374,21 @@
         },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
         },
         "node_modules/setimmediate": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "kind-of": "^6.0.2"
             },
@@ -7604,9 +15398,8 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -7616,18 +15409,16 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3",
@@ -7644,9 +15435,8 @@
         },
         "node_modules/side-channel-list": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3"
@@ -7660,9 +15450,8 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -7678,9 +15467,8 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -7697,8 +15485,6 @@
         },
         "node_modules/signal-exit": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -7710,8 +15496,6 @@
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
             "dev": true,
             "funding": [
                 {
@@ -7727,12 +15511,11 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "optional": true
         },
         "node_modules/simple-get": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "dev": true,
             "funding": [
                 {
@@ -7748,6 +15531,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "decompress-response": "^6.0.0",
@@ -7757,24 +15541,21 @@
         },
         "node_modules/sisteransi": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/slash": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/slice-ansi": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -7789,18 +15570,16 @@
         },
         "node_modules/source-map": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/source-map-support": {
             "version": "0.5.13",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -7808,9 +15587,8 @@
         },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -7818,15 +15596,13 @@
         },
         "node_modules/spdx-exceptions": {
             "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-            "dev": true
+            "dev": true,
+            "license": "CC-BY-3.0"
         },
         "node_modules/spdx-expression-parse": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -7834,21 +15610,18 @@
         },
         "node_modules/spdx-license-ids": {
             "version": "3.0.21",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-            "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
-            "dev": true
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "escape-string-regexp": "^2.0.0"
             },
@@ -7858,18 +15631,16 @@
         },
         "node_modules/stack-utils/node_modules/escape-string-regexp": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/stdin-discarder": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-            "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bl": "^5.0.0"
             },
@@ -7882,18 +15653,16 @@
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
         },
         "node_modules/string-length": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-            "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "char-regex": "^1.0.2",
                 "strip-ansi": "^6.0.0"
@@ -7904,18 +15673,16 @@
         },
         "node_modules/string-length/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/string-length/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -7925,8 +15692,6 @@
         },
         "node_modules/string-width": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7944,8 +15709,6 @@
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7959,8 +15722,6 @@
         },
         "node_modules/string-width-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7969,15 +15730,11 @@
         },
         "node_modules/string-width-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7989,8 +15746,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8006,8 +15761,6 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8019,8 +15772,6 @@
         },
         "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8029,18 +15780,16 @@
         },
         "node_modules/strip-bom": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/strip-final-newline": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -8050,9 +15799,8 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -8062,18 +15810,16 @@
         },
         "node_modules/structured-source": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
-            "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "boundary": "^2.0.0"
             }
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -8083,9 +15829,8 @@
         },
         "node_modules/supports-hyperlinks": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-            "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0",
                 "supports-color": "^7.0.0"
@@ -8096,9 +15841,8 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -8108,9 +15852,8 @@
         },
         "node_modules/system-architecture": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
-            "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -8120,9 +15863,8 @@
         },
         "node_modules/table": {
             "version": "6.9.0",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
-            "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",
@@ -8136,24 +15878,21 @@
         },
         "node_modules/table/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/table/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/table/node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -8165,9 +15904,8 @@
         },
         "node_modules/table/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -8177,18 +15915,16 @@
         },
         "node_modules/tapable": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/tar-fs": {
             "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-            "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "chownr": "^1.1.1",
@@ -8199,9 +15935,8 @@
         },
         "node_modules/tar-stream": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "bl": "^4.0.3",
@@ -8216,9 +15951,8 @@
         },
         "node_modules/tar-stream/node_modules/bl": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "buffer": "^5.5.0",
@@ -8228,8 +15962,6 @@
         },
         "node_modules/tar-stream/node_modules/buffer": {
             "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "dev": true,
             "funding": [
                 {
@@ -8245,6 +15977,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
@@ -8253,9 +15986,8 @@
         },
         "node_modules/tar-stream/node_modules/readable-stream": {
             "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -8268,18 +16000,16 @@
         },
         "node_modules/targz": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/targz/-/targz-1.0.1.tgz",
-            "integrity": "sha512-6q4tP9U55mZnRuMTBqnqc3nwYQY3kv+QthCFZuMk+Tn1qYUnMPmL/JZ/mzgXINzFpSqfU+242IFmFU9VPvqaQw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tar-fs": "^1.8.1"
             }
         },
         "node_modules/targz/node_modules/bl": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-            "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
@@ -8287,9 +16017,8 @@
         },
         "node_modules/targz/node_modules/pump": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-            "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -8297,9 +16026,8 @@
         },
         "node_modules/targz/node_modules/tar-fs": {
             "version": "1.16.5",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.5.tgz",
-            "integrity": "sha512-1ergVCCysmwHQNrOS+Pjm4DQ4nrGp43+Xnu4MRGjCnQu/m3hEgLNS78d5z+B8OJ1hN5EejJdCSFZE1oM6AQXAQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chownr": "^1.0.1",
                 "mkdirp": "^0.5.1",
@@ -8309,9 +16037,8 @@
         },
         "node_modules/targz/node_modules/tar-stream": {
             "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-            "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bl": "^1.0.0",
                 "buffer-alloc": "^1.2.0",
@@ -8327,9 +16054,8 @@
         },
         "node_modules/terminal-link": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-            "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-escapes": "^4.2.1",
                 "supports-hyperlinks": "^2.0.0"
@@ -8343,9 +16069,8 @@
         },
         "node_modules/test-exclude": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^7.1.4",
@@ -8357,10 +16082,8 @@
         },
         "node_modules/test-exclude/node_modules/glob": {
             "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -8378,15 +16101,13 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/textextensions": {
             "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
-            "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
             "dev": true,
+            "license": "Artistic-2.0",
             "dependencies": {
                 "editions": "^6.21.0"
             },
@@ -8399,30 +16120,26 @@
         },
         "node_modules/tmp": {
             "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.14"
             }
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/to-buffer": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -8432,42 +16149,34 @@
         },
         "node_modules/traverse": {
             "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
             "dev": true,
-            "engines": {
-                "node": "*"
-            }
+            "license": "MIT/X11"
         },
         "node_modules/truncate-utf8-bytes": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-            "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
             "dev": true,
+            "license": "WTFPL",
             "dependencies": {
                 "utf8-byte-length": "^1.0.1"
             }
         },
         "node_modules/tslib": {
             "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
             }
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
@@ -8478,18 +16187,16 @@
         },
         "node_modules/type-detect": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/type-fest": {
             "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "dev": true,
+            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
             },
@@ -8499,9 +16206,8 @@
         },
         "node_modules/typed-rest-client": {
             "version": "1.8.11",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
-            "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "qs": "^6.9.1",
                 "tunnel": "0.0.6",
@@ -8510,9 +16216,8 @@
         },
         "node_modules/typescript": {
             "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -8524,36 +16229,31 @@
         },
         "node_modules/uc.micro": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/underscore": {
             "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/undici": {
             "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
-            "integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
             "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unicorn-magic": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -8563,18 +16263,16 @@
         },
         "node_modules/universalify": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
             }
         },
         "node_modules/unzipper": {
             "version": "0.10.14",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-            "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",
@@ -8590,8 +16288,6 @@
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
             "dev": true,
             "funding": [
                 {
@@ -8607,6 +16303,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -8620,36 +16317,31 @@
         },
         "node_modules/url-join": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/utf8-byte-length": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
-            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
-            "dev": true
+            "dev": true,
+            "license": "(WTFPL OR MIT)"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/uuid": {
             "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-            "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -8661,9 +16353,8 @@
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -8671,9 +16362,8 @@
         },
         "node_modules/version-range": {
             "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.14.0.tgz",
-            "integrity": "sha512-gjb0ARm9qlcBAonU4zPwkl9ecKkas+tC2CGwFfptTCWWIVTWY1YUbT2zZKsOAF1jR/tNxxyLwwG0cb42XlYcTg==",
             "dev": true,
+            "license": "Artistic-2.0",
             "engines": {
                 "node": ">=4"
             },
@@ -8683,9 +16373,8 @@
         },
         "node_modules/vscode-extension-tester": {
             "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-8.15.0.tgz",
-            "integrity": "sha512-7eGada38DMsBWEzKicKy/3/sPGVZPQJM0RU4NW6KhTCHHhgMMTjANWZ4l1pT2oF3Pmets3efUI7RhNJTaVIeNA==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-developer/locators": "^1.13.0",
                 "@redhat-developer/page-objects": "^1.13.0",
@@ -8715,33 +16404,29 @@
         },
         "node_modules/vscode-extension-tester/node_modules/@bcoe/v8-coverage": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/vscode-extension-tester/node_modules/bluebird": {
             "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vscode-extension-tester/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
         "node_modules/vscode-extension-tester/node_modules/c8": {
             "version": "10.1.3",
-            "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
-            "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.1",
                 "@istanbuljs/schema": "^0.1.3",
@@ -8772,9 +16457,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/c8/node_modules/find-up": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -8788,9 +16472,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/find-up": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
-            "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "locate-path": "^7.2.0",
                 "path-exists": "^5.0.0",
@@ -8805,9 +16488,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/find-up/node_modules/locate-path": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-            "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-locate": "^6.0.0"
             },
@@ -8820,18 +16502,16 @@
         },
         "node_modules/vscode-extension-tester/node_modules/find-up/node_modules/path-exists": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-            "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
         "node_modules/vscode-extension-tester/node_modules/jackspeak": {
             "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
@@ -8844,15 +16524,13 @@
         },
         "node_modules/vscode-extension-tester/node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/vscode-extension-tester/node_modules/minimatch": {
             "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -8865,9 +16543,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/p-limit": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^1.0.0"
             },
@@ -8880,9 +16557,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/p-locate": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-            "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "p-limit": "^4.0.0"
             },
@@ -8895,9 +16571,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/path-scurry": {
             "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^10.2.0",
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -8911,9 +16586,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/test-exclude": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-            "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^10.4.1",
@@ -8925,9 +16599,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/test-exclude/node_modules/glob": {
             "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -8945,9 +16618,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/unzipper": {
             "version": "0.12.3",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
-            "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bluebird": "~3.7.2",
                 "duplexer2": "~0.1.4",
@@ -8958,9 +16630,8 @@
         },
         "node_modules/vscode-extension-tester/node_modules/yocto-queue": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-            "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12.20"
             },
@@ -8970,10 +16641,8 @@
         },
         "node_modules/vscode-test": {
             "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-            "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-            "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
                 "https-proxy-agent": "^5.0.0",
@@ -8986,18 +16655,16 @@
         },
         "node_modules/walker": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-            "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "makeerror": "1.0.12"
             }
         },
         "node_modules/whatwg-encoding": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -9007,17 +16674,15 @@
         },
         "node_modules/whatwg-mimetype": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/which": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+            "license": "ISC",
             "dependencies": {
                 "isexe": "^3.1.1"
             },
@@ -9030,14 +16695,11 @@
         },
         "node_modules/workerpool": {
             "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
-            "dev": true
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9055,8 +16717,6 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9073,8 +16733,6 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9083,15 +16741,11 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9105,8 +16759,6 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9118,8 +16770,6 @@
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {
             "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9131,15 +16781,13 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/write-file-atomic": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-            "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^3.0.7"
@@ -9150,15 +16798,13 @@
         },
         "node_modules/write-file-atomic/node_modules/signal-exit": {
             "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/ws": {
             "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -9177,9 +16823,8 @@
         },
         "node_modules/xml2js": {
             "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -9190,42 +16835,37 @@
         },
         "node_modules/xmlbuilder": {
             "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             }
         },
         "node_modules/xtend": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4"
             }
         },
         "node_modules/y18n": {
             "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/yallist": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/yargs": {
             "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -9241,18 +16881,16 @@
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/yargs-unparser": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.0.0",
                 "decamelize": "^4.0.0",
@@ -9265,24 +16903,21 @@
         },
         "node_modules/yargs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/yargs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/yargs/node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -9294,9 +16929,8 @@
         },
         "node_modules/yargs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -9306,9 +16940,8 @@
         },
         "node_modules/yauzl": {
             "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
@@ -9316,18 +16949,16 @@
         },
         "node_modules/yazl": {
             "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3"
             }
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "dependencies": {
         "@vscode/codicons": "0.0.36",
         "ajv": "^8.17.1",
-        "clingo-wasm": "file:../clingo-wasm",
+        "clingo-wasm": "^0.3.2",
         "which": "^5.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "answer-set-programming-language-support",
     "displayName": "Answer Set Programming Language Support",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Language Support for Clingo ASP (developed by University of Potsdam).",
     "publisher": "ffrankreiter",
     "jest": {
@@ -185,7 +185,7 @@
     "dependencies": {
         "@vscode/codicons": "0.0.36",
         "ajv": "^8.17.1",
-        "clingo-wasm": "^0.3.2",
+        "clingo-wasm": "file:../clingo-wasm",
         "which": "^5.0.0"
     }
 }

--- a/src/runClingoWasmForFileWithProgress.js
+++ b/src/runClingoWasmForFileWithProgress.js
@@ -48,10 +48,6 @@ async function runClingoWasmForFileWithProgress(vscode, progress, filePath, mode
         message: "Running Clingo WASM...",
     });
 
-    setTimeout(() => {
-        clingo.terminate();
-    }, 2000);
-
     // Run Clingo WASM with timeout
     const wasmResult = await clingo.run(fileContent, models, clingoOptions);
 

--- a/src/runClingoWasmForFileWithProgress.js
+++ b/src/runClingoWasmForFileWithProgress.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const clingo = require("clingo-wasm");
-//import { run, terminate } from "clingo-wasm";
 
 /**
  * @param {*} vscode Reference to vscode module import (workaround so we can test it)
@@ -43,9 +42,6 @@ async function runClingoWasmForFileWithProgress(vscode, progress, filePath, mode
 
     // Filter options for Clingo
     const clingoOptions = options?.filter((arg) => arg.startsWith("--"));
-
-    // Remove all sections starting with % and ending with \r\n
-    //fileContent = fileContent.replace(/%.*?\r\n/g, "");
 
     progress.report({
         increment: 50,

--- a/src/runClingoWasmForFileWithProgress.js
+++ b/src/runClingoWasmForFileWithProgress.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const clingo = require("clingo-wasm");
+//import { run, terminate } from "clingo-wasm";
 
 /**
  * @param {*} vscode Reference to vscode module import (workaround so we can test it)
@@ -44,12 +45,16 @@ async function runClingoWasmForFileWithProgress(vscode, progress, filePath, mode
     const clingoOptions = options?.filter((arg) => arg.startsWith("--"));
 
     // Remove all sections starting with % and ending with \r\n
-    fileContent = fileContent.replace(/%.*?\r\n/g, "");
+    //fileContent = fileContent.replace(/%.*?\r\n/g, "");
 
     progress.report({
         increment: 50,
         message: "Running Clingo WASM...",
     });
+
+    setTimeout(() => {
+        clingo.terminate();
+    }, 2000);
 
     // Run Clingo WASM with timeout
     const wasmResult = await clingo.run(fileContent, models, clingoOptions);


### PR DESCRIPTION
Fixed the bug mentioned in #72

We commentd the check that removed comments from the code passed onto clingo. This was previously done because WASM-Clingo didnt support large files, this is no longer the case so file size is irrelevant.